### PR TITLE
Fix negative guideline height to be int instead of string.

### DIFF
--- a/Source Files/Biryani-Bold.ufo/lib.plist
+++ b/Source Files/Biryani-Bold.ufo/lib.plist
@@ -93,7 +93,7 @@
 			<key>x</key>
 			<integer>388</integer>
 			<key>y</key>
-			<string>-350</string>
+			<integer>-350</integer>
 		</dict>
 	</array>
 	<key>com.typemytype.robofont.italicSlantOffset</key>

--- a/Source Files/Biryani-Light.ufo/lib.plist
+++ b/Source Files/Biryani-Light.ufo/lib.plist
@@ -93,7 +93,7 @@
 			<key>x</key>
 			<integer>388</integer>
 			<key>y</key>
-			<string>-350</string>
+			<integer>-350</integer>
 		</dict>
 	</array>
 	<key>com.typemytype.robofont.italicSlantOffset</key>


### PR DESCRIPTION
This issue made the UFOs unreadable in Robofont (I do not know where it comes from -- Glyphs UFO export maybe?)
