### PR TITLE
Fix negative integers in XML

### DIFF
--- a/Source Files/Biryani-Bold.ufo/glyphs/B_.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/B_.glif
@@ -81,7 +81,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-161</string>
+                  <integer>-161</integer>
                   <key>y</key>
                   <integer>408</integer>
                 </dict>
@@ -89,7 +89,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-122</string>
+                  <integer>-122</integer>
                   <key>y</key>
                   <integer>469</integer>
                 </dict>
@@ -99,7 +99,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-122</string>
+                  <integer>-122</integer>
                   <key>y</key>
                   <integer>555</integer>
                 </dict>
@@ -107,7 +107,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-122</string>
+                  <integer>-122</integer>
                   <key>y</key>
                   <integer>689</integer>
                 </dict>
@@ -115,7 +115,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-176</string>
+                  <integer>-176</integer>
                   <key>y</key>
                   <integer>758</integer>
                 </dict>
@@ -125,7 +125,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-349</string>
+                  <integer>-349</integer>
                   <key>y</key>
                   <integer>758</integer>
                 </dict>
@@ -135,7 +135,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-584</string>
+                  <integer>-584</integer>
                   <key>y</key>
                   <integer>758</integer>
                 </dict>
@@ -145,7 +145,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-584</string>
+                  <integer>-584</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -155,7 +155,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-349</string>
+                  <integer>-349</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -163,7 +163,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-158</string>
+                  <integer>-158</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -171,7 +171,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-92</string>
+                  <integer>-92</integer>
                   <key>y</key>
                   <integer>71</integer>
                 </dict>
@@ -181,7 +181,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-92</string>
+                  <integer>-92</integer>
                   <key>y</key>
                   <integer>202</integer>
                 </dict>
@@ -189,7 +189,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-92</string>
+                  <integer>-92</integer>
                   <key>y</key>
                   <integer>301</integer>
                 </dict>
@@ -197,7 +197,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-143</string>
+                  <integer>-143</integer>
                   <key>y</key>
                   <integer>364</integer>
                 </dict>
@@ -207,7 +207,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-248</string>
+                  <integer>-248</integer>
                   <key>y</key>
                   <integer>391</integer>
                 </dict>
@@ -217,7 +217,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-247</string>
+                  <integer>-247</integer>
                   <key>y</key>
                   <integer>377</integer>
                 </dict>
@@ -232,7 +232,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-349</string>
+                  <integer>-349</integer>
                   <key>y</key>
                   <integer>706</integer>
                 </dict>
@@ -240,7 +240,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-218</string>
+                  <integer>-218</integer>
                   <key>y</key>
                   <integer>706</integer>
                 </dict>
@@ -248,7 +248,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-179</string>
+                  <integer>-179</integer>
                   <key>y</key>
                   <integer>662</integer>
                 </dict>
@@ -258,7 +258,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-180</string>
+                  <integer>-180</integer>
                   <key>y</key>
                   <integer>555</integer>
                 </dict>
@@ -266,7 +266,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-181</string>
+                  <integer>-181</integer>
                   <key>y</key>
                   <integer>454</integer>
                 </dict>
@@ -274,7 +274,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-238</string>
+                  <integer>-238</integer>
                   <key>y</key>
                   <integer>406</integer>
                 </dict>
@@ -284,7 +284,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-349</string>
+                  <integer>-349</integer>
                   <key>y</key>
                   <integer>406</integer>
                 </dict>
@@ -294,7 +294,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-528</string>
+                  <integer>-528</integer>
                   <key>y</key>
                   <integer>406</integer>
                 </dict>
@@ -304,7 +304,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-528</string>
+                  <integer>-528</integer>
                   <key>y</key>
                   <integer>706</integer>
                 </dict>
@@ -317,7 +317,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-151</string>
+                  <integer>-151</integer>
                   <key>y</key>
                   <integer>100</integer>
                 </dict>
@@ -325,7 +325,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-201</string>
+                  <integer>-201</integer>
                   <key>y</key>
                   <integer>52</integer>
                 </dict>
@@ -335,7 +335,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-349</string>
+                  <integer>-349</integer>
                   <key>y</key>
                   <integer>52</integer>
                 </dict>
@@ -345,7 +345,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-528</string>
+                  <integer>-528</integer>
                   <key>y</key>
                   <integer>52</integer>
                 </dict>
@@ -355,7 +355,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-528</string>
+                  <integer>-528</integer>
                   <key>y</key>
                   <integer>354</integer>
                 </dict>
@@ -365,7 +365,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-349</string>
+                  <integer>-349</integer>
                   <key>y</key>
                   <integer>354</integer>
                 </dict>
@@ -373,7 +373,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-220</string>
+                  <integer>-220</integer>
                   <key>y</key>
                   <integer>354</integer>
                 </dict>
@@ -381,7 +381,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-149</string>
+                  <integer>-149</integer>
                   <key>y</key>
                   <integer>310</integer>
                 </dict>
@@ -391,7 +391,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-150</string>
+                  <integer>-150</integer>
                   <key>y</key>
                   <integer>202</integer>
                 </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/E_ng.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/E_ng.glif
@@ -206,7 +206,7 @@
                   <key>x</key>
                   <integer>629</integer>
                   <key>y</key>
-                  <string>-166</string>
+                  <integer>-166</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -214,7 +214,7 @@
                   <key>x</key>
                   <integer>655</integer>
                   <key>y</key>
-                  <string>-132</string>
+                  <integer>-132</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -224,7 +224,7 @@
                   <key>x</key>
                   <integer>655</integer>
                   <key>y</key>
-                  <string>-5</string>
+                  <integer>-5</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -262,7 +262,7 @@
                   <key>x</key>
                   <integer>599</integer>
                   <key>y</key>
-                  <string>-93</string>
+                  <integer>-93</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -270,7 +270,7 @@
                   <key>x</key>
                   <integer>585</integer>
                   <key>y</key>
-                  <string>-112</string>
+                  <integer>-112</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -280,7 +280,7 @@
                   <key>x</key>
                   <integer>536</integer>
                   <key>y</key>
-                  <string>-112</string>
+                  <integer>-112</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -288,7 +288,7 @@
                   <key>x</key>
                   <integer>521</integer>
                   <key>y</key>
-                  <string>-112</string>
+                  <integer>-112</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -296,7 +296,7 @@
                   <key>x</key>
                   <integer>505</integer>
                   <key>y</key>
-                  <string>-111</string>
+                  <integer>-111</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -306,7 +306,7 @@
                   <key>x</key>
                   <integer>490</integer>
                   <key>y</key>
-                  <string>-108</string>
+                  <integer>-108</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -316,7 +316,7 @@
                   <key>x</key>
                   <integer>490</integer>
                   <key>y</key>
-                  <string>-162</string>
+                  <integer>-162</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -324,7 +324,7 @@
                   <key>x</key>
                   <integer>505</integer>
                   <key>y</key>
-                  <string>-165</string>
+                  <integer>-165</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -332,7 +332,7 @@
                   <key>x</key>
                   <integer>520</integer>
                   <key>y</key>
-                  <string>-166</string>
+                  <integer>-166</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -342,7 +342,7 @@
                   <key>x</key>
                   <integer>531</integer>
                   <key>y</key>
-                  <string>-166</string>
+                  <integer>-166</integer>
                 </dict>
               </array>
             </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/L_slash.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/L_slash.glif
@@ -31,7 +31,7 @@
                 <integer>0</integer>
                 <integer>0</integer>
                 <integer>1</integer>
-                <string>-10</string>
+                <integer>-10</integer>
                 <integer>0</integer>
               </array>
             </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/S_.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/S_.glif
@@ -399,7 +399,7 @@
                   <key>x</key>
                   <integer>241</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -409,7 +409,7 @@
                   <key>x</key>
                   <integer>335</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -417,7 +417,7 @@
                   <key>x</key>
                   <integer>485</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>

--- a/Source Files/Biryani-Bold.ufo/glyphs/V_.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/V_.glif
@@ -107,7 +107,7 @@
                   <key>x</key>
                   <integer>386</integer>
                   <key>y</key>
-                  <string>-9</string>
+                  <integer>-9</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -117,7 +117,7 @@
                   <key>x</key>
                   <integer>434</integer>
                   <key>y</key>
-                  <string>-9</string>
+                  <integer>-9</integer>
                 </dict>
               </array>
             </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/W_.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/W_.glif
@@ -148,7 +148,7 @@
                   <key>x</key>
                   <integer>346</integer>
                   <key>y</key>
-                  <string>-9</string>
+                  <integer>-9</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -158,7 +158,7 @@
                   <key>x</key>
                   <integer>394</integer>
                   <key>y</key>
-                  <string>-9</string>
+                  <integer>-9</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -188,7 +188,7 @@
                   <key>x</key>
                   <integer>805</integer>
                   <key>y</key>
-                  <string>-9</string>
+                  <integer>-9</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -198,7 +198,7 @@
                   <key>x</key>
                   <integer>853</integer>
                   <key>y</key>
-                  <string>-9</string>
+                  <integer>-9</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>

--- a/Source Files/Biryani-Bold.ufo/glyphs/a.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/a.glif
@@ -99,7 +99,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-889</string>
+                  <integer>-889</integer>
                   <key>y</key>
                   <integer>546</integer>
                 </dict>
@@ -109,7 +109,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-889</string>
+                  <integer>-889</integer>
                   <key>y</key>
                   <integer>496</integer>
                 </dict>
@@ -119,7 +119,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-835</string>
+                  <integer>-835</integer>
                   <key>y</key>
                   <integer>496</integer>
                 </dict>
@@ -127,7 +127,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-699</string>
+                  <integer>-699</integer>
                   <key>y</key>
                   <integer>496</integer>
                 </dict>
@@ -135,7 +135,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-691</string>
+                  <integer>-691</integer>
                   <key>y</key>
                   <integer>423</integer>
                 </dict>
@@ -145,7 +145,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-691</string>
+                  <integer>-691</integer>
                   <key>y</key>
                   <integer>303</integer>
                 </dict>
@@ -155,7 +155,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-691</string>
+                  <integer>-691</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -165,7 +165,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-637</string>
+                  <integer>-637</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -175,7 +175,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-637</string>
+                  <integer>-637</integer>
                   <key>y</key>
                   <integer>313</integer>
                 </dict>
@@ -183,7 +183,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-637</string>
+                  <integer>-637</integer>
                   <key>y</key>
                   <integer>445</integer>
                 </dict>
@@ -191,7 +191,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-659</string>
+                  <integer>-659</integer>
                   <key>y</key>
                   <integer>546</integer>
                 </dict>
@@ -201,7 +201,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-820</string>
+                  <integer>-820</integer>
                   <key>y</key>
                   <integer>546</integer>
                 </dict>
@@ -214,7 +214,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-707</string>
+                  <integer>-707</integer>
                   <key>y</key>
                   <integer>344</integer>
                 </dict>
@@ -222,7 +222,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-773</string>
+                  <integer>-773</integer>
                   <key>y</key>
                   <integer>362</integer>
                 </dict>
@@ -232,7 +232,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-825</string>
+                  <integer>-825</integer>
                   <key>y</key>
                   <integer>362</integer>
                 </dict>
@@ -240,7 +240,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-945</string>
+                  <integer>-945</integer>
                   <key>y</key>
                   <integer>362</integer>
                 </dict>
@@ -248,7 +248,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1030</string>
+                  <integer>-1030</integer>
                   <key>y</key>
                   <integer>295</integer>
                 </dict>
@@ -258,7 +258,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1030</string>
+                  <integer>-1030</integer>
                   <key>y</key>
                   <integer>173</integer>
                 </dict>
@@ -266,7 +266,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1030</string>
+                  <integer>-1030</integer>
                   <key>y</key>
                   <integer>55</integer>
                 </dict>
@@ -274,9 +274,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-946</string>
+                  <integer>-946</integer>
                   <key>y</key>
-                  <string>-13</string>
+                  <integer>-13</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -284,23 +284,23 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-855</string>
+                  <integer>-855</integer>
                   <key>y</key>
-                  <string>-13</string>
+                  <integer>-13</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-786</string>
+                  <integer>-786</integer>
                   <key>y</key>
-                  <string>-13</string>
+                  <integer>-13</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-728</string>
+                  <integer>-728</integer>
                   <key>y</key>
                   <integer>16</integer>
                 </dict>
@@ -310,7 +310,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-666</string>
+                  <integer>-666</integer>
                   <key>y</key>
                   <integer>85</integer>
                 </dict>
@@ -320,7 +320,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-667</string>
+                  <integer>-667</integer>
                   <key>y</key>
                   <integer>139</integer>
                 </dict>
@@ -328,7 +328,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-729</string>
+                  <integer>-729</integer>
                   <key>y</key>
                   <integer>70</integer>
                 </dict>
@@ -336,7 +336,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-797</string>
+                  <integer>-797</integer>
                   <key>y</key>
                   <integer>41</integer>
                 </dict>
@@ -346,7 +346,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-855</string>
+                  <integer>-855</integer>
                   <key>y</key>
                   <integer>41</integer>
                 </dict>
@@ -354,7 +354,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-904</string>
+                  <integer>-904</integer>
                   <key>y</key>
                   <integer>41</integer>
                 </dict>
@@ -362,7 +362,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-974</string>
+                  <integer>-974</integer>
                   <key>y</key>
                   <integer>72</integer>
                 </dict>
@@ -372,7 +372,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-974</string>
+                  <integer>-974</integer>
                   <key>y</key>
                   <integer>173</integer>
                 </dict>
@@ -380,7 +380,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-974</string>
+                  <integer>-974</integer>
                   <key>y</key>
                   <integer>280</integer>
                 </dict>
@@ -388,7 +388,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-894</string>
+                  <integer>-894</integer>
                   <key>y</key>
                   <integer>308</integer>
                 </dict>
@@ -398,7 +398,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-825</string>
+                  <integer>-825</integer>
                   <key>y</key>
                   <integer>308</integer>
                 </dict>
@@ -406,7 +406,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-777</string>
+                  <integer>-777</integer>
                   <key>y</key>
                   <integer>308</integer>
                 </dict>
@@ -414,7 +414,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-718</string>
+                  <integer>-718</integer>
                   <key>y</key>
                   <integer>297</integer>
                 </dict>
@@ -424,7 +424,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-670</string>
+                  <integer>-670</integer>
                   <key>y</key>
                   <integer>264</integer>
                 </dict>
@@ -434,7 +434,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-664</string>
+                  <integer>-664</integer>
                   <key>y</key>
                   <integer>312</integer>
                 </dict>
@@ -449,7 +449,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-424</string>
+                  <integer>-424</integer>
                   <key>y</key>
                   <integer>546</integer>
                 </dict>
@@ -459,7 +459,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-424</string>
+                  <integer>-424</integer>
                   <key>y</key>
                   <integer>386</integer>
                 </dict>
@@ -469,7 +469,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-270</string>
+                  <integer>-270</integer>
                   <key>y</key>
                   <integer>386</integer>
                 </dict>
@@ -477,7 +477,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-207</string>
+                  <integer>-207</integer>
                   <key>y</key>
                   <integer>386</integer>
                 </dict>
@@ -485,7 +485,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-196</string>
+                  <integer>-196</integer>
                   <key>y</key>
                   <integer>358</integer>
                 </dict>
@@ -495,7 +495,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-196</string>
+                  <integer>-196</integer>
                   <key>y</key>
                   <integer>313</integer>
                 </dict>
@@ -505,7 +505,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-196</string>
+                  <integer>-196</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -515,7 +515,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2</string>
+                  <integer>-2</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -525,7 +525,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-2</string>
+                  <integer>-2</integer>
                   <key>y</key>
                   <integer>313</integer>
                 </dict>
@@ -533,7 +533,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2</string>
+                  <integer>-2</integer>
                   <key>y</key>
                   <integer>445</integer>
                 </dict>
@@ -541,7 +541,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-32</string>
+                  <integer>-32</integer>
                   <key>y</key>
                   <integer>546</integer>
                 </dict>
@@ -551,7 +551,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-255</string>
+                  <integer>-255</integer>
                   <key>y</key>
                   <integer>546</integer>
                 </dict>
@@ -564,7 +564,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-171</string>
+                  <integer>-171</integer>
                   <key>y</key>
                   <integer>330</integer>
                 </dict>
@@ -572,7 +572,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-236</string>
+                  <integer>-236</integer>
                   <key>y</key>
                   <integer>352</integer>
                 </dict>
@@ -582,7 +582,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-312</string>
+                  <integer>-312</integer>
                   <key>y</key>
                   <integer>352</integer>
                 </dict>
@@ -590,7 +590,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-444</string>
+                  <integer>-444</integer>
                   <key>y</key>
                   <integer>352</integer>
                 </dict>
@@ -598,7 +598,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-525</string>
+                  <integer>-525</integer>
                   <key>y</key>
                   <integer>287</integer>
                 </dict>
@@ -608,7 +608,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-525</string>
+                  <integer>-525</integer>
                   <key>y</key>
                   <integer>168</integer>
                 </dict>
@@ -616,7 +616,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-525</string>
+                  <integer>-525</integer>
                   <key>y</key>
                   <integer>53</integer>
                 </dict>
@@ -624,9 +624,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-446</string>
+                  <integer>-446</integer>
                   <key>y</key>
-                  <string>-13</string>
+                  <integer>-13</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -634,23 +634,23 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-342</string>
+                  <integer>-342</integer>
                   <key>y</key>
-                  <string>-13</string>
+                  <integer>-13</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-247</string>
+                  <integer>-247</integer>
                   <key>y</key>
-                  <string>-13</string>
+                  <integer>-13</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-192</string>
+                  <integer>-192</integer>
                   <key>y</key>
                   <integer>17</integer>
                 </dict>
@@ -660,7 +660,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-121</string>
+                  <integer>-121</integer>
                   <key>y</key>
                   <integer>95</integer>
                 </dict>
@@ -670,7 +670,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-122</string>
+                  <integer>-122</integer>
                   <key>y</key>
                   <integer>224</integer>
                 </dict>
@@ -678,7 +678,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-180</string>
+                  <integer>-180</integer>
                   <key>y</key>
                   <integer>160</integer>
                 </dict>
@@ -686,7 +686,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-231</string>
+                  <integer>-231</integer>
                   <key>y</key>
                   <integer>126</integer>
                 </dict>
@@ -696,7 +696,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-280</string>
+                  <integer>-280</integer>
                   <key>y</key>
                   <integer>126</integer>
                 </dict>
@@ -704,7 +704,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-300</string>
+                  <integer>-300</integer>
                   <key>y</key>
                   <integer>126</integer>
                 </dict>
@@ -712,7 +712,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-329</string>
+                  <integer>-329</integer>
                   <key>y</key>
                   <integer>137</integer>
                 </dict>
@@ -722,7 +722,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-329</string>
+                  <integer>-329</integer>
                   <key>y</key>
                   <integer>173</integer>
                 </dict>
@@ -730,7 +730,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-329</string>
+                  <integer>-329</integer>
                   <key>y</key>
                   <integer>213</integer>
                 </dict>
@@ -738,7 +738,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-293</string>
+                  <integer>-293</integer>
                   <key>y</key>
                   <integer>223</integer>
                 </dict>
@@ -748,7 +748,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-260</string>
+                  <integer>-260</integer>
                   <key>y</key>
                   <integer>223</integer>
                 </dict>
@@ -756,7 +756,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-218</string>
+                  <integer>-218</integer>
                   <key>y</key>
                   <integer>223</integer>
                 </dict>
@@ -764,7 +764,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-169</string>
+                  <integer>-169</integer>
                   <key>y</key>
                   <integer>210</integer>
                 </dict>
@@ -774,7 +774,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-125</string>
+                  <integer>-125</integer>
                   <key>y</key>
                   <integer>179</integer>
                 </dict>
@@ -784,7 +784,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-119</string>
+                  <integer>-119</integer>
                   <key>y</key>
                   <integer>292</integer>
                 </dict>
@@ -976,7 +976,7 @@
                   <key>x</key>
                   <integer>184</integer>
                   <key>y</key>
-                  <string>-13</string>
+                  <integer>-13</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -986,7 +986,7 @@
                   <key>x</key>
                   <integer>275</integer>
                   <key>y</key>
-                  <string>-13</string>
+                  <integer>-13</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -994,7 +994,7 @@
                   <key>x</key>
                   <integer>344</integer>
                   <key>y</key>
-                  <string>-13</string>
+                  <integer>-13</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>

--- a/Source Files/Biryani-Bold.ufo/glyphs/ae.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/ae.glif
@@ -283,7 +283,7 @@
                   <key>x</key>
                   <integer>119</integer>
                   <key>y</key>
-                  <string>-13</string>
+                  <integer>-13</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -293,7 +293,7 @@
                   <key>x</key>
                   <integer>210</integer>
                   <key>y</key>
-                  <string>-13</string>
+                  <integer>-13</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -301,7 +301,7 @@
                   <key>x</key>
                   <integer>291</integer>
                   <key>y</key>
-                  <string>-13</string>
+                  <integer>-13</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -624,7 +624,7 @@
                   <key>x</key>
                   <integer>463</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -634,7 +634,7 @@
                   <key>x</key>
                   <integer>632</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -642,7 +642,7 @@
                   <key>x</key>
                   <integer>695</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -650,7 +650,7 @@
                   <key>x</key>
                   <integer>758</integer>
                   <key>y</key>
-                  <string>-1</string>
+                  <integer>-1</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>

--- a/Source Files/Biryani-Bold.ufo/glyphs/aiM_atra-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/aiM_atra-deva.glif
@@ -50,7 +50,7 @@
               <key>name</key>
               <string>top</string>
               <key>x</key>
-              <string>-37</string>
+              <integer>-37</integer>
               <key>y</key>
               <integer>634</integer>
             </dict>
@@ -58,7 +58,7 @@
               <key>name</key>
               <string>_top</string>
               <key>x</key>
-              <string>-138</string>
+              <integer>-138</integer>
               <key>y</key>
               <integer>634</integer>
             </dict>
@@ -77,7 +77,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-109</string>
+                  <integer>-109</integer>
                   <key>y</key>
                   <integer>624</integer>
                 </dict>
@@ -87,7 +87,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-160</string>
+                  <integer>-160</integer>
                   <key>y</key>
                   <integer>850</integer>
                 </dict>
@@ -95,7 +95,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-186</string>
+                  <integer>-186</integer>
                   <key>y</key>
                   <integer>965</integer>
                 </dict>
@@ -103,7 +103,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-235</string>
+                  <integer>-235</integer>
                   <key>y</key>
                   <integer>984</integer>
                 </dict>
@@ -113,7 +113,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-335</string>
+                  <integer>-335</integer>
                   <key>y</key>
                   <integer>984</integer>
                 </dict>
@@ -123,7 +123,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-410</string>
+                  <integer>-410</integer>
                   <key>y</key>
                   <integer>984</integer>
                 </dict>
@@ -133,7 +133,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-410</string>
+                  <integer>-410</integer>
                   <key>y</key>
                   <integer>940</integer>
                 </dict>
@@ -143,7 +143,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-335</string>
+                  <integer>-335</integer>
                   <key>y</key>
                   <integer>940</integer>
                 </dict>
@@ -151,7 +151,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-263</string>
+                  <integer>-263</integer>
                   <key>y</key>
                   <integer>940</integer>
                 </dict>
@@ -159,7 +159,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-230</string>
+                  <integer>-230</integer>
                   <key>y</key>
                   <integer>922</integer>
                 </dict>
@@ -169,7 +169,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-214</string>
+                  <integer>-214</integer>
                   <key>y</key>
                   <integer>850</integer>
                 </dict>
@@ -179,7 +179,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-163</string>
+                  <integer>-163</integer>
                   <key>y</key>
                   <integer>624</integer>
                 </dict>
@@ -194,7 +194,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-116</string>
+                  <integer>-116</integer>
                   <key>y</key>
                   <integer>624</integer>
                 </dict>
@@ -204,7 +204,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-171</string>
+                  <integer>-171</integer>
                   <key>y</key>
                   <integer>699</integer>
                 </dict>
@@ -212,7 +212,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-247</string>
+                  <integer>-247</integer>
                   <key>y</key>
                   <integer>802</integer>
                 </dict>
@@ -220,7 +220,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-274</string>
+                  <integer>-274</integer>
                   <key>y</key>
                   <integer>834</integer>
                 </dict>
@@ -230,7 +230,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-415</string>
+                  <integer>-415</integer>
                   <key>y</key>
                   <integer>834</integer>
                 </dict>
@@ -240,7 +240,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-500</string>
+                  <integer>-500</integer>
                   <key>y</key>
                   <integer>834</integer>
                 </dict>
@@ -250,7 +250,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-500</string>
+                  <integer>-500</integer>
                   <key>y</key>
                   <integer>790</integer>
                 </dict>
@@ -260,7 +260,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-415</string>
+                  <integer>-415</integer>
                   <key>y</key>
                   <integer>790</integer>
                 </dict>
@@ -268,7 +268,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-308</string>
+                  <integer>-308</integer>
                   <key>y</key>
                   <integer>790</integer>
                 </dict>
@@ -276,7 +276,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-272</string>
+                  <integer>-272</integer>
                   <key>y</key>
                   <integer>761</integer>
                 </dict>
@@ -286,7 +286,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-223</string>
+                  <integer>-223</integer>
                   <key>y</key>
                   <integer>699</integer>
                 </dict>
@@ -296,7 +296,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-163</string>
+                  <integer>-163</integer>
                   <key>y</key>
                   <integer>624</integer>
                 </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/at.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/at.glif
@@ -149,7 +149,7 @@
                   <key>x</key>
                   <integer>67</integer>
                   <key>y</key>
-                  <string>-54</string>
+                  <integer>-54</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -157,7 +157,7 @@
                   <key>x</key>
                   <integer>241</integer>
                   <key>y</key>
-                  <string>-212</string>
+                  <integer>-212</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -167,7 +167,7 @@
                   <key>x</key>
                   <integer>486</integer>
                   <key>y</key>
-                  <string>-212</string>
+                  <integer>-212</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -175,7 +175,7 @@
                   <key>x</key>
                   <integer>600</integer>
                   <key>y</key>
-                  <string>-212</string>
+                  <integer>-212</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -183,7 +183,7 @@
                   <key>x</key>
                   <integer>683</integer>
                   <key>y</key>
-                  <string>-179</string>
+                  <integer>-179</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -193,7 +193,7 @@
                   <key>x</key>
                   <integer>768</integer>
                   <key>y</key>
-                  <string>-137</string>
+                  <integer>-137</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -203,7 +203,7 @@
                   <key>x</key>
                   <integer>748</integer>
                   <key>y</key>
-                  <string>-87</string>
+                  <integer>-87</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -211,7 +211,7 @@
                   <key>x</key>
                   <integer>665</integer>
                   <key>y</key>
-                  <string>-130</string>
+                  <integer>-130</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -219,7 +219,7 @@
                   <key>x</key>
                   <integer>584</integer>
                   <key>y</key>
-                  <string>-160</string>
+                  <integer>-160</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -229,7 +229,7 @@
                   <key>x</key>
                   <integer>486</integer>
                   <key>y</key>
-                  <string>-160</string>
+                  <integer>-160</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -237,7 +237,7 @@
                   <key>x</key>
                   <integer>240</integer>
                   <key>y</key>
-                  <string>-160</string>
+                  <integer>-160</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>

--- a/Source Files/Biryani-Bold.ufo/glyphs/b.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/b.glif
@@ -298,7 +298,7 @@
                   <key>x</key>
                   <integer>290</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -308,7 +308,7 @@
                   <key>x</key>
                   <integer>361</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -316,7 +316,7 @@
                   <key>x</key>
                   <integer>502</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>

--- a/Source Files/Biryani-Bold.ufo/glyphs/bar.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/bar.glif
@@ -45,7 +45,7 @@
                   <key>x</key>
                   <integer>140</integer>
                   <key>y</key>
-                  <string>-129</string>
+                  <integer>-129</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -55,7 +55,7 @@
                   <key>x</key>
                   <integer>196</integer>
                   <key>y</key>
-                  <string>-129</string>
+                  <integer>-129</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>

--- a/Source Files/Biryani-Bold.ufo/glyphs/braceleft.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/braceleft.glif
@@ -79,7 +79,7 @@
                   <key>x</key>
                   <integer>346</integer>
                   <key>y</key>
-                  <string>-129</string>
+                  <integer>-129</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -87,7 +87,7 @@
                   <key>x</key>
                   <integer>361</integer>
                   <key>y</key>
-                  <string>-128</string>
+                  <integer>-128</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -97,7 +97,7 @@
                   <key>x</key>
                   <integer>376</integer>
                   <key>y</key>
-                  <string>-125</string>
+                  <integer>-125</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -107,7 +107,7 @@
                   <key>x</key>
                   <integer>376</integer>
                   <key>y</key>
-                  <string>-71</string>
+                  <integer>-71</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -115,7 +115,7 @@
                   <key>x</key>
                   <integer>361</integer>
                   <key>y</key>
-                  <string>-74</string>
+                  <integer>-74</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -123,7 +123,7 @@
                   <key>x</key>
                   <integer>345</integer>
                   <key>y</key>
-                  <string>-75</string>
+                  <integer>-75</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -133,7 +133,7 @@
                   <key>x</key>
                   <integer>330</integer>
                   <key>y</key>
-                  <string>-75</string>
+                  <integer>-75</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -141,7 +141,7 @@
                   <key>x</key>
                   <integer>280</integer>
                   <key>y</key>
-                  <string>-75</string>
+                  <integer>-75</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -149,7 +149,7 @@
                   <key>x</key>
                   <integer>266</integer>
                   <key>y</key>
-                  <string>-59</string>
+                  <integer>-59</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -159,7 +159,7 @@
                   <key>x</key>
                   <integer>266</integer>
                   <key>y</key>
-                  <string>-2</string>
+                  <integer>-2</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -261,7 +261,7 @@
                   <key>x</key>
                   <integer>210</integer>
                   <key>y</key>
-                  <string>-8</string>
+                  <integer>-8</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -269,7 +269,7 @@
                   <key>x</key>
                   <integer>210</integer>
                   <key>y</key>
-                  <string>-103</string>
+                  <integer>-103</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -277,7 +277,7 @@
                   <key>x</key>
                   <integer>246</integer>
                   <key>y</key>
-                  <string>-129</string>
+                  <integer>-129</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -287,7 +287,7 @@
                   <key>x</key>
                   <integer>335</integer>
                   <key>y</key>
-                  <string>-129</string>
+                  <integer>-129</integer>
                 </dict>
               </array>
             </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/c.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/c.glif
@@ -85,7 +85,7 @@
                   <key>x</key>
                   <integer>156</integer>
                   <key>y</key>
-                  <string>-16</string>
+                  <integer>-16</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -95,7 +95,7 @@
                   <key>x</key>
                   <integer>325</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -103,7 +103,7 @@
                   <key>x</key>
                   <integer>388</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -111,7 +111,7 @@
                   <key>x</key>
                   <integer>450</integer>
                   <key>y</key>
-                  <string>-1</string>
+                  <integer>-1</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>

--- a/Source Files/Biryani-Bold.ufo/glyphs/c_ca-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/c_ca-deva.glif
@@ -324,7 +324,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-40</string>
+                  <integer>-40</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -334,7 +334,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-40</string>
+                  <integer>-40</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -630,7 +630,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-6</string>
+                  <integer>-6</integer>
                   <key>y</key>
                   <integer>440</integer>
                 </dict>
@@ -640,7 +640,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-6</string>
+                  <integer>-6</integer>
                   <key>y</key>
                   <integer>396</integer>
                 </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/cedilla.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/cedilla.glif
@@ -72,7 +72,7 @@
                   <key>x</key>
                   <integer>370</integer>
                   <key>y</key>
-                  <string>-263</string>
+                  <integer>-263</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -80,7 +80,7 @@
                   <key>x</key>
                   <integer>412</integer>
                   <key>y</key>
-                  <string>-222</string>
+                  <integer>-222</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -90,7 +90,7 @@
                   <key>x</key>
                   <integer>412</integer>
                   <key>y</key>
-                  <string>-165</string>
+                  <integer>-165</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -98,7 +98,7 @@
                   <key>x</key>
                   <integer>412</integer>
                   <key>y</key>
-                  <string>-111</string>
+                  <integer>-111</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -106,7 +106,7 @@
                   <key>x</key>
                   <integer>375</integer>
                   <key>y</key>
-                  <string>-72</string>
+                  <integer>-72</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -116,7 +116,7 @@
                   <key>x</key>
                   <integer>303</integer>
                   <key>y</key>
-                  <string>-72</string>
+                  <integer>-72</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -124,7 +124,7 @@
                   <key>x</key>
                   <integer>281</integer>
                   <key>y</key>
-                  <string>-72</string>
+                  <integer>-72</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -132,7 +132,7 @@
                   <key>x</key>
                   <integer>261</integer>
                   <key>y</key>
-                  <string>-81</string>
+                  <integer>-81</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -142,7 +142,7 @@
                   <key>x</key>
                   <integer>243</integer>
                   <key>y</key>
-                  <string>-90</string>
+                  <integer>-90</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -152,7 +152,7 @@
                   <key>x</key>
                   <integer>218</integer>
                   <key>y</key>
-                  <string>-136</string>
+                  <integer>-136</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -160,7 +160,7 @@
                   <key>x</key>
                   <integer>245</integer>
                   <key>y</key>
-                  <string>-127</string>
+                  <integer>-127</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -168,7 +168,7 @@
                   <key>x</key>
                   <integer>273</integer>
                   <key>y</key>
-                  <string>-119</string>
+                  <integer>-119</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -178,7 +178,7 @@
                   <key>x</key>
                   <integer>303</integer>
                   <key>y</key>
-                  <string>-119</string>
+                  <integer>-119</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -186,7 +186,7 @@
                   <key>x</key>
                   <integer>346</integer>
                   <key>y</key>
-                  <string>-119</string>
+                  <integer>-119</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -194,7 +194,7 @@
                   <key>x</key>
                   <integer>361</integer>
                   <key>y</key>
-                  <string>-139</string>
+                  <integer>-139</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -204,7 +204,7 @@
                   <key>x</key>
                   <integer>361</integer>
                   <key>y</key>
-                  <string>-165</string>
+                  <integer>-165</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -212,7 +212,7 @@
                   <key>x</key>
                   <integer>361</integer>
                   <key>y</key>
-                  <string>-189</string>
+                  <integer>-189</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -220,7 +220,7 @@
                   <key>x</key>
                   <integer>342</integer>
                   <key>y</key>
-                  <string>-216</string>
+                  <integer>-216</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -230,7 +230,7 @@
                   <key>x</key>
                   <integer>290</integer>
                   <key>y</key>
-                  <string>-216</string>
+                  <integer>-216</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -238,7 +238,7 @@
                   <key>x</key>
                   <integer>260</integer>
                   <key>y</key>
-                  <string>-216</string>
+                  <integer>-216</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -246,7 +246,7 @@
                   <key>x</key>
                   <integer>231</integer>
                   <key>y</key>
-                  <string>-210</string>
+                  <integer>-210</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -256,7 +256,7 @@
                   <key>x</key>
                   <integer>198</integer>
                   <key>y</key>
-                  <string>-195</string>
+                  <integer>-195</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -266,7 +266,7 @@
                   <key>x</key>
                   <integer>198</integer>
                   <key>y</key>
-                  <string>-243</string>
+                  <integer>-243</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -274,7 +274,7 @@
                   <key>x</key>
                   <integer>231</integer>
                   <key>y</key>
-                  <string>-258</string>
+                  <integer>-258</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -282,7 +282,7 @@
                   <key>x</key>
                   <integer>260</integer>
                   <key>y</key>
-                  <string>-263</string>
+                  <integer>-263</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -292,7 +292,7 @@
                   <key>x</key>
                   <integer>290</integer>
                   <key>y</key>
-                  <string>-263</string>
+                  <integer>-263</integer>
                 </dict>
               </array>
             </dict>
@@ -317,7 +317,7 @@
                   <key>x</key>
                   <integer>218</integer>
                   <key>y</key>
-                  <string>-136</string>
+                  <integer>-136</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -327,7 +327,7 @@
                   <key>x</key>
                   <integer>278</integer>
                   <key>y</key>
-                  <string>-106</string>
+                  <integer>-106</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>

--- a/Source Files/Biryani-Bold.ufo/glyphs/cent.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/cent.glif
@@ -59,7 +59,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-471</string>
+                  <integer>-471</integer>
                   <key>y</key>
                   <integer>102</integer>
                 </dict>
@@ -67,9 +67,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-382</string>
+                  <integer>-382</integer>
                   <key>y</key>
-                  <string>-16</string>
+                  <integer>-16</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -77,25 +77,25 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-213</string>
+                  <integer>-213</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-150</string>
+                  <integer>-150</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-88</string>
+                  <integer>-88</integer>
                   <key>y</key>
-                  <string>-1</string>
+                  <integer>-1</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -103,7 +103,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-30</string>
+                  <integer>-30</integer>
                   <key>y</key>
                   <integer>28</integer>
                 </dict>
@@ -113,7 +113,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-50</string>
+                  <integer>-50</integer>
                   <key>y</key>
                   <integer>78</integer>
                 </dict>
@@ -121,7 +121,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-103</string>
+                  <integer>-103</integer>
                   <key>y</key>
                   <integer>54</integer>
                 </dict>
@@ -129,7 +129,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-158</string>
+                  <integer>-158</integer>
                   <key>y</key>
                   <integer>37</integer>
                 </dict>
@@ -139,7 +139,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-213</string>
+                  <integer>-213</integer>
                   <key>y</key>
                   <integer>37</integer>
                 </dict>
@@ -147,7 +147,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-362</string>
+                  <integer>-362</integer>
                   <key>y</key>
                   <integer>38</integer>
                 </dict>
@@ -155,7 +155,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-415</string>
+                  <integer>-415</integer>
                   <key>y</key>
                   <integer>144</integer>
                 </dict>
@@ -165,7 +165,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-415</string>
+                  <integer>-415</integer>
                   <key>y</key>
                   <integer>275</integer>
                 </dict>
@@ -173,7 +173,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-415</string>
+                  <integer>-415</integer>
                   <key>y</key>
                   <integer>403</integer>
                 </dict>
@@ -181,7 +181,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-362</string>
+                  <integer>-362</integer>
                   <key>y</key>
                   <integer>507</integer>
                 </dict>
@@ -191,7 +191,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-213</string>
+                  <integer>-213</integer>
                   <key>y</key>
                   <integer>508</integer>
                 </dict>
@@ -199,7 +199,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-164</string>
+                  <integer>-164</integer>
                   <key>y</key>
                   <integer>508</integer>
                 </dict>
@@ -207,7 +207,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-124</string>
+                  <integer>-124</integer>
                   <key>y</key>
                   <integer>501</integer>
                 </dict>
@@ -217,7 +217,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-74</string>
+                  <integer>-74</integer>
                   <key>y</key>
                   <integer>477</integer>
                 </dict>
@@ -227,7 +227,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-74</string>
+                  <integer>-74</integer>
                   <key>y</key>
                   <integer>535</integer>
                 </dict>
@@ -235,7 +235,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-119</string>
+                  <integer>-119</integer>
                   <key>y</key>
                   <integer>553</integer>
                 </dict>
@@ -243,7 +243,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-155</string>
+                  <integer>-155</integer>
                   <key>y</key>
                   <integer>562</integer>
                 </dict>
@@ -253,7 +253,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-213</string>
+                  <integer>-213</integer>
                   <key>y</key>
                   <integer>562</integer>
                 </dict>
@@ -261,7 +261,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-382</string>
+                  <integer>-382</integer>
                   <key>y</key>
                   <integer>561</integer>
                 </dict>
@@ -269,7 +269,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-471</string>
+                  <integer>-471</integer>
                   <key>y</key>
                   <integer>444</integer>
                 </dict>
@@ -279,7 +279,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-471</string>
+                  <integer>-471</integer>
                   <key>y</key>
                   <integer>274</integer>
                 </dict>
@@ -294,9 +294,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-242</string>
+                  <integer>-242</integer>
                   <key>y</key>
-                  <string>-96</string>
+                  <integer>-96</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -304,9 +304,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-186</string>
+                  <integer>-186</integer>
                   <key>y</key>
-                  <string>-96</string>
+                  <integer>-96</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -314,7 +314,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-186</string>
+                  <integer>-186</integer>
                   <key>y</key>
                   <integer>641</integer>
                 </dict>
@@ -324,7 +324,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-242</string>
+                  <integer>-242</integer>
                   <key>y</key>
                   <integer>641</integer>
                 </dict>
@@ -347,7 +347,7 @@
                   <key>x</key>
                   <integer>168</integer>
                   <key>y</key>
-                  <string>-16</string>
+                  <integer>-16</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -357,7 +357,7 @@
                   <key>x</key>
                   <integer>337</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -365,7 +365,7 @@
                   <key>x</key>
                   <integer>400</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -373,7 +373,7 @@
                   <key>x</key>
                   <integer>462</integer>
                   <key>y</key>
-                  <string>-1</string>
+                  <integer>-1</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -574,7 +574,7 @@
                   <key>x</key>
                   <integer>308</integer>
                   <key>y</key>
-                  <string>-96</string>
+                  <integer>-96</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -584,7 +584,7 @@
                   <key>x</key>
                   <integer>364</integer>
                   <key>y</key>
-                  <string>-96</string>
+                  <integer>-96</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>

--- a/Source Files/Biryani-Bold.ufo/glyphs/ch_na-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/ch_na-deva.glif
@@ -118,7 +118,7 @@
               <key>x</key>
               <integer>400</integer>
               <key>y</key>
-              <string>-229</string>
+              <integer>-229</integer>
             </dict>
             <dict>
               <key>name</key>
@@ -126,7 +126,7 @@
               <key>x</key>
               <integer>565</integer>
               <key>y</key>
-              <string>-237</string>
+              <integer>-237</integer>
             </dict>
             <dict>
               <key>name</key>
@@ -516,7 +516,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -526,7 +526,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -767,7 +767,7 @@
                   <key>x</key>
                   <integer>538</integer>
                   <key>y</key>
-                  <string>-237</string>
+                  <integer>-237</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -777,7 +777,7 @@
                   <key>x</key>
                   <integer>592</integer>
                   <key>y</key>
-                  <string>-237</string>
+                  <integer>-237</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -802,7 +802,7 @@
                   <key>x</key>
                   <integer>581</integer>
                   <key>y</key>
-                  <string>-29</string>
+                  <integer>-29</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -838,7 +838,7 @@
                   <key>x</key>
                   <integer>213</integer>
                   <key>y</key>
-                  <string>-5</string>
+                  <integer>-5</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -848,7 +848,7 @@
                   <key>x</key>
                   <integer>213</integer>
                   <key>y</key>
-                  <string>-49</string>
+                  <integer>-49</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -856,7 +856,7 @@
                   <key>x</key>
                   <integer>213</integer>
                   <key>y</key>
-                  <string>-92</string>
+                  <integer>-92</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -864,7 +864,7 @@
                   <key>x</key>
                   <integer>243</integer>
                   <key>y</key>
-                  <string>-124</string>
+                  <integer>-124</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -874,7 +874,7 @@
                   <key>x</key>
                   <integer>297</integer>
                   <key>y</key>
-                  <string>-148</string>
+                  <integer>-148</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -884,7 +884,7 @@
                   <key>x</key>
                   <integer>318</integer>
                   <key>y</key>
-                  <string>-106</string>
+                  <integer>-106</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -892,7 +892,7 @@
                   <key>x</key>
                   <integer>289</integer>
                   <key>y</key>
-                  <string>-91</string>
+                  <integer>-91</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -900,7 +900,7 @@
                   <key>x</key>
                   <integer>267</integer>
                   <key>y</key>
-                  <string>-74</string>
+                  <integer>-74</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -910,7 +910,7 @@
                   <key>x</key>
                   <integer>267</integer>
                   <key>y</key>
-                  <string>-54</string>
+                  <integer>-54</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -918,7 +918,7 @@
                   <key>x</key>
                   <integer>267</integer>
                   <key>y</key>
-                  <string>-34</string>
+                  <integer>-34</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -926,7 +926,7 @@
                   <key>x</key>
                   <integer>279</integer>
                   <key>y</key>
-                  <string>-29</string>
+                  <integer>-29</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -936,7 +936,7 @@
                   <key>x</key>
                   <integer>308</integer>
                   <key>y</key>
-                  <string>-29</string>
+                  <integer>-29</integer>
                 </dict>
               </array>
             </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/commaaccent.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/commaaccent.glif
@@ -52,9 +52,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-338</string>
+                  <integer>-338</integer>
                   <key>y</key>
-                  <string>-80</string>
+                  <integer>-80</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -62,9 +62,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-370</string>
+                  <integer>-370</integer>
                   <key>y</key>
-                  <string>-246</string>
+                  <integer>-246</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -72,9 +72,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-316</string>
+                  <integer>-316</integer>
                   <key>y</key>
-                  <string>-246</string>
+                  <integer>-246</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -82,9 +82,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-278</string>
+                  <integer>-278</integer>
                   <key>y</key>
-                  <string>-80</string>
+                  <integer>-80</integer>
                 </dict>
               </array>
             </dict>
@@ -99,7 +99,7 @@
                   <key>x</key>
                   <integer>311</integer>
                   <key>y</key>
-                  <string>-80</string>
+                  <integer>-80</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -109,7 +109,7 @@
                   <key>x</key>
                   <integer>279</integer>
                   <key>y</key>
-                  <string>-246</string>
+                  <integer>-246</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -119,7 +119,7 @@
                   <key>x</key>
                   <integer>333</integer>
                   <key>y</key>
-                  <string>-246</string>
+                  <integer>-246</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -129,7 +129,7 @@
                   <key>x</key>
                   <integer>371</integer>
                   <key>y</key>
-                  <string>-80</string>
+                  <integer>-80</integer>
                 </dict>
               </array>
             </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/d.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/d.glif
@@ -96,7 +96,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-799</string>
+                  <integer>-799</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -106,7 +106,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-745</string>
+                  <integer>-745</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -116,7 +116,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-745</string>
+                  <integer>-745</integer>
                   <key>y</key>
                   <integer>846</integer>
                 </dict>
@@ -126,7 +126,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-799</string>
+                  <integer>-799</integer>
                   <key>y</key>
                   <integer>846</integer>
                 </dict>
@@ -139,7 +139,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1201</string>
+                  <integer>-1201</integer>
                   <key>y</key>
                   <integer>78</integer>
                 </dict>
@@ -147,9 +147,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1104</string>
+                  <integer>-1104</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -157,23 +157,23 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-963</string>
+                  <integer>-963</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-892</string>
+                  <integer>-892</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-821</string>
+                  <integer>-821</integer>
                   <key>y</key>
                   <integer>30</integer>
                 </dict>
@@ -183,7 +183,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-771</string>
+                  <integer>-771</integer>
                   <key>y</key>
                   <integer>85</integer>
                 </dict>
@@ -193,7 +193,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-771</string>
+                  <integer>-771</integer>
                   <key>y</key>
                   <integer>139</integer>
                 </dict>
@@ -201,7 +201,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-822</string>
+                  <integer>-822</integer>
                   <key>y</key>
                   <integer>83</integer>
                 </dict>
@@ -209,7 +209,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-888</string>
+                  <integer>-888</integer>
                   <key>y</key>
                   <integer>37</integer>
                 </dict>
@@ -219,7 +219,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-963</string>
+                  <integer>-963</integer>
                   <key>y</key>
                   <integer>37</integer>
                 </dict>
@@ -227,7 +227,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1083</string>
+                  <integer>-1083</integer>
                   <key>y</key>
                   <integer>37</integer>
                 </dict>
@@ -235,7 +235,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1145</string>
+                  <integer>-1145</integer>
                   <key>y</key>
                   <integer>119</integer>
                 </dict>
@@ -245,7 +245,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1145</string>
+                  <integer>-1145</integer>
                   <key>y</key>
                   <integer>273</integer>
                 </dict>
@@ -253,7 +253,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1145</string>
+                  <integer>-1145</integer>
                   <key>y</key>
                   <integer>426</integer>
                 </dict>
@@ -261,7 +261,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1083</string>
+                  <integer>-1083</integer>
                   <key>y</key>
                   <integer>508</integer>
                 </dict>
@@ -271,7 +271,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-963</string>
+                  <integer>-963</integer>
                   <key>y</key>
                   <integer>508</integer>
                 </dict>
@@ -279,7 +279,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-888</string>
+                  <integer>-888</integer>
                   <key>y</key>
                   <integer>508</integer>
                 </dict>
@@ -287,7 +287,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-822</string>
+                  <integer>-822</integer>
                   <key>y</key>
                   <integer>462</integer>
                 </dict>
@@ -297,7 +297,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-771</string>
+                  <integer>-771</integer>
                   <key>y</key>
                   <integer>406</integer>
                 </dict>
@@ -307,7 +307,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-771</string>
+                  <integer>-771</integer>
                   <key>y</key>
                   <integer>460</integer>
                 </dict>
@@ -315,7 +315,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-821</string>
+                  <integer>-821</integer>
                   <key>y</key>
                   <integer>515</integer>
                 </dict>
@@ -323,7 +323,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-892</string>
+                  <integer>-892</integer>
                   <key>y</key>
                   <integer>562</integer>
                 </dict>
@@ -333,7 +333,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-963</string>
+                  <integer>-963</integer>
                   <key>y</key>
                   <integer>562</integer>
                 </dict>
@@ -341,7 +341,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1104</string>
+                  <integer>-1104</integer>
                   <key>y</key>
                   <integer>562</integer>
                 </dict>
@@ -349,7 +349,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1201</string>
+                  <integer>-1201</integer>
                   <key>y</key>
                   <integer>467</integer>
                 </dict>
@@ -359,7 +359,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1201</string>
+                  <integer>-1201</integer>
                   <key>y</key>
                   <integer>273</integer>
                 </dict>
@@ -374,7 +374,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-226</string>
+                  <integer>-226</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -384,7 +384,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-22</string>
+                  <integer>-22</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -394,7 +394,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-22</string>
+                  <integer>-22</integer>
                   <key>y</key>
                   <integer>846</integer>
                 </dict>
@@ -404,7 +404,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-226</string>
+                  <integer>-226</integer>
                   <key>y</key>
                   <integer>846</integer>
                 </dict>
@@ -417,7 +417,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-618</string>
+                  <integer>-618</integer>
                   <key>y</key>
                   <integer>79</integer>
                 </dict>
@@ -425,9 +425,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-511</string>
+                  <integer>-511</integer>
                   <key>y</key>
-                  <string>-16</string>
+                  <integer>-16</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -435,23 +435,23 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-368</string>
+                  <integer>-368</integer>
                   <key>y</key>
-                  <string>-16</string>
+                  <integer>-16</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-284</string>
+                  <integer>-284</integer>
                   <key>y</key>
-                  <string>-16</string>
+                  <integer>-16</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-219</string>
+                  <integer>-219</integer>
                   <key>y</key>
                   <integer>28</integer>
                 </dict>
@@ -461,7 +461,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-168</string>
+                  <integer>-168</integer>
                   <key>y</key>
                   <integer>85</integer>
                 </dict>
@@ -471,7 +471,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-168</string>
+                  <integer>-168</integer>
                   <key>y</key>
                   <integer>244</integer>
                 </dict>
@@ -479,7 +479,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-214</string>
+                  <integer>-214</integer>
                   <key>y</key>
                   <integer>193</integer>
                 </dict>
@@ -487,7 +487,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-256</string>
+                  <integer>-256</integer>
                   <key>y</key>
                   <integer>142</integer>
                 </dict>
@@ -497,7 +497,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-320</string>
+                  <integer>-320</integer>
                   <key>y</key>
                   <integer>142</integer>
                 </dict>
@@ -505,7 +505,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-386</string>
+                  <integer>-386</integer>
                   <key>y</key>
                   <integer>142</integer>
                 </dict>
@@ -513,7 +513,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-422</string>
+                  <integer>-422</integer>
                   <key>y</key>
                   <string>-1.232529278</string>
                 </dict>
@@ -523,7 +523,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-422</string>
+                  <integer>-422</integer>
                   <key>y</key>
                   <integer>273</integer>
                 </dict>
@@ -531,7 +531,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-422</string>
+                  <integer>-422</integer>
                   <key>y</key>
                   <real>357.24</real>
                 </dict>
@@ -539,7 +539,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-386</string>
+                  <integer>-386</integer>
                   <key>y</key>
                   <integer>403</integer>
                 </dict>
@@ -549,7 +549,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-320</string>
+                  <integer>-320</integer>
                   <key>y</key>
                   <integer>403</integer>
                 </dict>
@@ -557,7 +557,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-256</string>
+                  <integer>-256</integer>
                   <key>y</key>
                   <integer>403</integer>
                 </dict>
@@ -565,7 +565,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-214</string>
+                  <integer>-214</integer>
                   <key>y</key>
                   <integer>352</integer>
                 </dict>
@@ -575,7 +575,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-168</string>
+                  <integer>-168</integer>
                   <key>y</key>
                   <integer>301</integer>
                 </dict>
@@ -585,7 +585,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-168</string>
+                  <integer>-168</integer>
                   <key>y</key>
                   <integer>460</integer>
                 </dict>
@@ -593,7 +593,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-219</string>
+                  <integer>-219</integer>
                   <key>y</key>
                   <integer>517</integer>
                 </dict>
@@ -601,7 +601,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-263</string>
+                  <integer>-263</integer>
                   <key>y</key>
                   <integer>562</integer>
                 </dict>
@@ -611,7 +611,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-368</string>
+                  <integer>-368</integer>
                   <key>y</key>
                   <integer>562</integer>
                 </dict>
@@ -619,7 +619,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-511</string>
+                  <integer>-511</integer>
                   <key>y</key>
                   <integer>562</integer>
                 </dict>
@@ -627,7 +627,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-618</string>
+                  <integer>-618</integer>
                   <key>y</key>
                   <integer>467</integer>
                 </dict>
@@ -637,7 +637,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-618</string>
+                  <integer>-618</integer>
                   <key>y</key>
                   <integer>273</integer>
                 </dict>
@@ -705,7 +705,7 @@
                   <key>x</key>
                   <integer>202</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -715,7 +715,7 @@
                   <key>x</key>
                   <integer>343</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -723,7 +723,7 @@
                   <key>x</key>
                   <integer>414</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>

--- a/Source Files/Biryani-Bold.ufo/glyphs/da-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/da-deva.glif
@@ -72,7 +72,7 @@
               <key>x</key>
               <integer>288</integer>
               <key>y</key>
-              <string>-80</string>
+              <integer>-80</integer>
             </dict>
             <dict>
               <key>name</key>
@@ -80,7 +80,7 @@
               <key>x</key>
               <integer>415</integer>
               <key>y</key>
-              <string>-15</string>
+              <integer>-15</integer>
             </dict>
             <dict>
               <key>name</key>
@@ -96,7 +96,7 @@
               <key>x</key>
               <integer>288</integer>
               <key>y</key>
-              <string>-80</string>
+              <integer>-80</integer>
             </dict>
             <dict>
               <key>name</key>
@@ -129,7 +129,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-160</string>
+                  <integer>-160</integer>
                   <key>y</key>
                   <integer>214</integer>
                 </dict>
@@ -139,9 +139,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-160</string>
+                  <integer>-160</integer>
                   <key>y</key>
-                  <string>-15</string>
+                  <integer>-15</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -149,9 +149,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-106</string>
+                  <integer>-106</integer>
                   <key>y</key>
-                  <string>-15</string>
+                  <integer>-15</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -159,7 +159,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-106</string>
+                  <integer>-106</integer>
                   <key>y</key>
                   <integer>214</integer>
                 </dict>
@@ -172,7 +172,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-199</string>
+                  <integer>-199</integer>
                   <key>y</key>
                   <integer>74</integer>
                 </dict>
@@ -180,7 +180,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-173</string>
+                  <integer>-173</integer>
                   <key>y</key>
                   <integer>77</integer>
                 </dict>
@@ -190,7 +190,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-145</string>
+                  <integer>-145</integer>
                   <key>y</key>
                   <integer>84</integer>
                 </dict>
@@ -200,7 +200,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-145</string>
+                  <integer>-145</integer>
                   <key>y</key>
                   <integer>130</integer>
                 </dict>
@@ -208,7 +208,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-177</string>
+                  <integer>-177</integer>
                   <key>y</key>
                   <integer>121</integer>
                 </dict>
@@ -216,7 +216,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-201</string>
+                  <integer>-201</integer>
                   <key>y</key>
                   <integer>118</integer>
                 </dict>
@@ -226,7 +226,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-234</string>
+                  <integer>-234</integer>
                   <key>y</key>
                   <integer>118</integer>
                 </dict>
@@ -236,7 +236,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-252</string>
+                  <integer>-252</integer>
                   <key>y</key>
                   <integer>118</integer>
                 </dict>
@@ -244,7 +244,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-355</string>
+                  <integer>-355</integer>
                   <key>y</key>
                   <integer>118</integer>
                 </dict>
@@ -252,7 +252,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-413</string>
+                  <integer>-413</integer>
                   <key>y</key>
                   <integer>145</integer>
                 </dict>
@@ -262,7 +262,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-413</string>
+                  <integer>-413</integer>
                   <key>y</key>
                   <integer>277</integer>
                 </dict>
@@ -270,7 +270,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-413</string>
+                  <integer>-413</integer>
                   <key>y</key>
                   <integer>410</integer>
                 </dict>
@@ -278,7 +278,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-348</string>
+                  <integer>-348</integer>
                   <key>y</key>
                   <integer>436</integer>
                 </dict>
@@ -288,7 +288,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-242</string>
+                  <integer>-242</integer>
                   <key>y</key>
                   <integer>436</integer>
                 </dict>
@@ -298,7 +298,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-130</string>
+                  <integer>-130</integer>
                   <key>y</key>
                   <integer>436</integer>
                 </dict>
@@ -308,7 +308,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-130</string>
+                  <integer>-130</integer>
                   <key>y</key>
                   <integer>480</integer>
                 </dict>
@@ -318,7 +318,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-242</string>
+                  <integer>-242</integer>
                   <key>y</key>
                   <integer>480</integer>
                 </dict>
@@ -326,7 +326,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-390</string>
+                  <integer>-390</integer>
                   <key>y</key>
                   <integer>480</integer>
                 </dict>
@@ -334,7 +334,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-467</string>
+                  <integer>-467</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -344,7 +344,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-467</string>
+                  <integer>-467</integer>
                   <key>y</key>
                   <integer>277</integer>
                 </dict>
@@ -352,7 +352,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-467</string>
+                  <integer>-467</integer>
                   <key>y</key>
                   <integer>125</integer>
                 </dict>
@@ -360,7 +360,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-395</string>
+                  <integer>-395</integer>
                   <key>y</key>
                   <integer>74</integer>
                 </dict>
@@ -370,7 +370,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-252</string>
+                  <integer>-252</integer>
                   <key>y</key>
                   <integer>74</integer>
                 </dict>
@@ -380,7 +380,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-234</string>
+                  <integer>-234</integer>
                   <key>y</key>
                   <integer>74</integer>
                 </dict>
@@ -395,7 +395,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-539</string>
+                  <integer>-539</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -405,7 +405,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-539</string>
+                  <integer>-539</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -415,7 +415,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-184</string>
+                  <integer>-184</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -425,7 +425,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-184</string>
+                  <integer>-184</integer>
                   <key>y</key>
                   <integer>451</integer>
                 </dict>
@@ -435,7 +435,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-130</string>
+                  <integer>-130</integer>
                   <key>y</key>
                   <integer>451</integer>
                 </dict>
@@ -445,7 +445,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-130</string>
+                  <integer>-130</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -455,7 +455,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -465,7 +465,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -746,7 +746,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>674</integer>
                 </dict>
@@ -756,7 +756,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>550</integer>
                 </dict>
@@ -831,7 +831,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-42</string>
+                  <integer>-42</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -841,7 +841,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-42</string>
+                  <integer>-42</integer>
                   <key>y</key>
                   <integer>510</integer>
                 </dict>
@@ -863,7 +863,7 @@
                   <key>x</key>
                   <integer>339</integer>
                   <key>y</key>
-                  <string>-40</string>
+                  <integer>-40</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -873,7 +873,7 @@
                   <key>x</key>
                   <integer>493</integer>
                   <key>y</key>
-                  <string>-40</string>
+                  <integer>-40</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>

--- a/Source Files/Biryani-Bold.ufo/glyphs/dd_dda-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/dd_dda-deva.glif
@@ -119,7 +119,7 @@
               <key>x</key>
               <integer>287</integer>
               <key>y</key>
-              <string>-164</string>
+              <integer>-164</integer>
             </dict>
           </array>
           <key>components</key>
@@ -136,7 +136,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -146,7 +146,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -610,7 +610,7 @@
                   <key>x</key>
                   <integer>103</integer>
                   <key>y</key>
-                  <string>-13</string>
+                  <integer>-13</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -620,7 +620,7 @@
                   <key>x</key>
                   <integer>124</integer>
                   <key>y</key>
-                  <string>-29</string>
+                  <integer>-29</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -630,7 +630,7 @@
                   <key>x</key>
                   <integer>280</integer>
                   <key>y</key>
-                  <string>-29</string>
+                  <integer>-29</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -638,7 +638,7 @@
                   <key>x</key>
                   <integer>349</integer>
                   <key>y</key>
-                  <string>-29</string>
+                  <integer>-29</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -646,7 +646,7 @@
                   <key>x</key>
                   <integer>388</integer>
                   <key>y</key>
-                  <string>-45</string>
+                  <integer>-45</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -656,7 +656,7 @@
                   <key>x</key>
                   <integer>390</integer>
                   <key>y</key>
-                  <string>-98</string>
+                  <integer>-98</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -664,7 +664,7 @@
                   <key>x</key>
                   <integer>392</integer>
                   <key>y</key>
-                  <string>-142</string>
+                  <integer>-142</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -672,7 +672,7 @@
                   <key>x</key>
                   <integer>349</integer>
                   <key>y</key>
-                  <string>-163</string>
+                  <integer>-163</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -682,7 +682,7 @@
                   <key>x</key>
                   <integer>280</integer>
                   <key>y</key>
-                  <string>-163</string>
+                  <integer>-163</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -692,7 +692,7 @@
                   <key>x</key>
                   <integer>265</integer>
                   <key>y</key>
-                  <string>-163</string>
+                  <integer>-163</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -700,7 +700,7 @@
                   <key>x</key>
                   <integer>177</integer>
                   <key>y</key>
-                  <string>-163</string>
+                  <integer>-163</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -708,7 +708,7 @@
                   <key>x</key>
                   <integer>114</integer>
                   <key>y</key>
-                  <string>-143</string>
+                  <integer>-143</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -718,7 +718,7 @@
                   <key>x</key>
                   <integer>53</integer>
                   <key>y</key>
-                  <string>-104</string>
+                  <integer>-104</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -728,7 +728,7 @@
                   <key>x</key>
                   <integer>31</integer>
                   <key>y</key>
-                  <string>-144</string>
+                  <integer>-144</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -736,7 +736,7 @@
                   <key>x</key>
                   <integer>95</integer>
                   <key>y</key>
-                  <string>-185</string>
+                  <integer>-185</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -744,7 +744,7 @@
                   <key>x</key>
                   <integer>167</integer>
                   <key>y</key>
-                  <string>-207</string>
+                  <integer>-207</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -754,7 +754,7 @@
                   <key>x</key>
                   <integer>265</integer>
                   <key>y</key>
-                  <string>-207</string>
+                  <integer>-207</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -764,7 +764,7 @@
                   <key>x</key>
                   <integer>280</integer>
                   <key>y</key>
-                  <string>-207</string>
+                  <integer>-207</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -772,7 +772,7 @@
                   <key>x</key>
                   <integer>382</integer>
                   <key>y</key>
-                  <string>-207</string>
+                  <integer>-207</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -780,7 +780,7 @@
                   <key>x</key>
                   <integer>444</integer>
                   <key>y</key>
-                  <string>-169</string>
+                  <integer>-169</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -790,7 +790,7 @@
                   <key>x</key>
                   <integer>444</integer>
                   <key>y</key>
-                  <string>-98</string>
+                  <integer>-98</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -798,7 +798,7 @@
                   <key>x</key>
                   <integer>444</integer>
                   <key>y</key>
-                  <string>-20</string>
+                  <integer>-20</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>

--- a/Source Files/Biryani-Bold.ufo/glyphs/dh-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/dh-deva.glif
@@ -68,7 +68,7 @@
               <key>x</key>
               <integer>350</integer>
               <key>y</key>
-              <string>-18</string>
+              <integer>-18</integer>
             </dict>
             <dict>
               <key>name</key>
@@ -99,7 +99,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-272</string>
+                  <integer>-272</integer>
                   <key>y</key>
                   <integer>587</integer>
                 </dict>
@@ -107,7 +107,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-229</string>
+                  <integer>-229</integer>
                   <key>y</key>
                   <integer>603</integer>
                 </dict>
@@ -117,7 +117,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-152</string>
+                  <integer>-152</integer>
                   <key>y</key>
                   <integer>603</integer>
                 </dict>
@@ -127,7 +127,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-140</string>
+                  <integer>-140</integer>
                   <key>y</key>
                   <integer>603</integer>
                 </dict>
@@ -135,7 +135,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-134</string>
+                  <integer>-134</integer>
                   <key>y</key>
                   <integer>603</integer>
                 </dict>
@@ -143,7 +143,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-119</string>
+                  <integer>-119</integer>
                   <key>y</key>
                   <integer>602</integer>
                 </dict>
@@ -153,7 +153,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-109</string>
+                  <integer>-109</integer>
                   <key>y</key>
                   <integer>601</integer>
                 </dict>
@@ -163,7 +163,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-109</string>
+                  <integer>-109</integer>
                   <key>y</key>
                   <integer>645</integer>
                 </dict>
@@ -171,7 +171,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-116</string>
+                  <integer>-116</integer>
                   <key>y</key>
                   <integer>646</integer>
                 </dict>
@@ -179,7 +179,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-129</string>
+                  <integer>-129</integer>
                   <key>y</key>
                   <integer>647</integer>
                 </dict>
@@ -189,7 +189,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-140</string>
+                  <integer>-140</integer>
                   <key>y</key>
                   <integer>647</integer>
                 </dict>
@@ -199,7 +199,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-152</string>
+                  <integer>-152</integer>
                   <key>y</key>
                   <integer>647</integer>
                 </dict>
@@ -207,7 +207,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-268</string>
+                  <integer>-268</integer>
                   <key>y</key>
                   <integer>647</integer>
                 </dict>
@@ -215,7 +215,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-326</string>
+                  <integer>-326</integer>
                   <key>y</key>
                   <integer>611</integer>
                 </dict>
@@ -225,7 +225,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-326</string>
+                  <integer>-326</integer>
                   <key>y</key>
                   <integer>505</integer>
                 </dict>
@@ -233,7 +233,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-326</string>
+                  <integer>-326</integer>
                   <key>y</key>
                   <integer>395</integer>
                 </dict>
@@ -241,7 +241,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-252</string>
+                  <integer>-252</integer>
                   <key>y</key>
                   <integer>362</integer>
                 </dict>
@@ -251,7 +251,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-106</string>
+                  <integer>-106</integer>
                   <key>y</key>
                   <integer>362</integer>
                 </dict>
@@ -261,7 +261,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-88</string>
+                  <integer>-88</integer>
                   <key>y</key>
                   <integer>362</integer>
                 </dict>
@@ -271,7 +271,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-88</string>
+                  <integer>-88</integer>
                   <key>y</key>
                   <integer>406</integer>
                 </dict>
@@ -281,7 +281,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-106</string>
+                  <integer>-106</integer>
                   <key>y</key>
                   <integer>406</integer>
                 </dict>
@@ -289,7 +289,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-212</string>
+                  <integer>-212</integer>
                   <key>y</key>
                   <integer>406</integer>
                 </dict>
@@ -297,7 +297,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-271</string>
+                  <integer>-271</integer>
                   <key>y</key>
                   <integer>419</integer>
                 </dict>
@@ -307,7 +307,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-272</string>
+                  <integer>-272</integer>
                   <key>y</key>
                   <integer>505</integer>
                 </dict>
@@ -320,7 +320,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-236</string>
+                  <integer>-236</integer>
                   <key>y</key>
                   <integer>345</integer>
                 </dict>
@@ -328,7 +328,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-188</string>
+                  <integer>-188</integer>
                   <key>y</key>
                   <integer>362</integer>
                 </dict>
@@ -338,7 +338,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-106</string>
+                  <integer>-106</integer>
                   <key>y</key>
                   <integer>362</integer>
                 </dict>
@@ -348,7 +348,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-77</string>
+                  <integer>-77</integer>
                   <key>y</key>
                   <integer>362</integer>
                 </dict>
@@ -358,7 +358,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-77</string>
+                  <integer>-77</integer>
                   <key>y</key>
                   <integer>406</integer>
                 </dict>
@@ -368,7 +368,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-106</string>
+                  <integer>-106</integer>
                   <key>y</key>
                   <integer>406</integer>
                 </dict>
@@ -376,7 +376,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-228</string>
+                  <integer>-228</integer>
                   <key>y</key>
                   <integer>406</integer>
                 </dict>
@@ -384,7 +384,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-290</string>
+                  <integer>-290</integer>
                   <key>y</key>
                   <integer>369</integer>
                 </dict>
@@ -394,7 +394,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-290</string>
+                  <integer>-290</integer>
                   <key>y</key>
                   <integer>259</integer>
                 </dict>
@@ -402,7 +402,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-290</string>
+                  <integer>-290</integer>
                   <key>y</key>
                   <integer>146</integer>
                 </dict>
@@ -410,7 +410,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-228</string>
+                  <integer>-228</integer>
                   <key>y</key>
                   <integer>113</integer>
                 </dict>
@@ -420,7 +420,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-106</string>
+                  <integer>-106</integer>
                   <key>y</key>
                   <integer>112</integer>
                 </dict>
@@ -430,7 +430,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-88</string>
+                  <integer>-88</integer>
                   <key>y</key>
                   <integer>112</integer>
                 </dict>
@@ -438,7 +438,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-7</string>
+                  <integer>-7</integer>
                   <key>y</key>
                   <integer>112</integer>
                 </dict>
@@ -482,7 +482,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                   <key>y</key>
                   <integer>156</integer>
                 </dict>
@@ -492,7 +492,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-88</string>
+                  <integer>-88</integer>
                   <key>y</key>
                   <integer>156</integer>
                 </dict>
@@ -502,7 +502,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-106</string>
+                  <integer>-106</integer>
                   <key>y</key>
                   <integer>156</integer>
                 </dict>
@@ -510,7 +510,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-189</string>
+                  <integer>-189</integer>
                   <key>y</key>
                   <integer>157</integer>
                 </dict>
@@ -518,7 +518,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-236</string>
+                  <integer>-236</integer>
                   <key>y</key>
                   <integer>169</integer>
                 </dict>
@@ -528,7 +528,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-236</string>
+                  <integer>-236</integer>
                   <key>y</key>
                   <integer>259</integer>
                 </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/dha-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/dha-deva.glif
@@ -85,7 +85,7 @@
               <key>x</key>
               <integer>350</integer>
               <key>y</key>
-              <string>-18</string>
+              <integer>-18</integer>
             </dict>
             <dict>
               <key>name</key>
@@ -687,7 +687,7 @@
                   <key>x</key>
                   <integer>441</integer>
                   <key>y</key>
-                  <string>-23</string>
+                  <integer>-23</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -697,7 +697,7 @@
                   <key>x</key>
                   <integer>595</integer>
                   <key>y</key>
-                  <string>-23</string>
+                  <integer>-23</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>

--- a/Source Files/Biryani-Bold.ufo/glyphs/e.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/e.glif
@@ -99,7 +99,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1571</string>
+                  <integer>-1571</integer>
                   <key>y</key>
                   <integer>37</integer>
                 </dict>
@@ -107,7 +107,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1624</string>
+                  <integer>-1624</integer>
                   <key>y</key>
                   <integer>145</integer>
                 </dict>
@@ -117,7 +117,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1624</string>
+                  <integer>-1624</integer>
                   <key>y</key>
                   <integer>275</integer>
                 </dict>
@@ -125,7 +125,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1624</string>
+                  <integer>-1624</integer>
                   <key>y</key>
                   <integer>434</integer>
                 </dict>
@@ -133,7 +133,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1552</string>
+                  <integer>-1552</integer>
                   <key>y</key>
                   <integer>508</integer>
                 </dict>
@@ -143,7 +143,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1442</string>
+                  <integer>-1442</integer>
                   <key>y</key>
                   <integer>508</integer>
                 </dict>
@@ -151,7 +151,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1331</string>
+                  <integer>-1331</integer>
                   <key>y</key>
                   <integer>508</integer>
                 </dict>
@@ -159,7 +159,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1281</string>
+                  <integer>-1281</integer>
                   <key>y</key>
                   <integer>446</integer>
                 </dict>
@@ -169,7 +169,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1281</string>
+                  <integer>-1281</integer>
                   <key>y</key>
                   <integer>310</integer>
                 </dict>
@@ -179,7 +179,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1281</string>
+                  <integer>-1281</integer>
                   <key>y</key>
                   <integer>289</integer>
                 </dict>
@@ -189,7 +189,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1225</string>
+                  <integer>-1225</integer>
                   <key>y</key>
                   <integer>289</integer>
                 </dict>
@@ -199,7 +199,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1225</string>
+                  <integer>-1225</integer>
                   <key>y</key>
                   <integer>310</integer>
                 </dict>
@@ -207,7 +207,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1226</string>
+                  <integer>-1226</integer>
                   <key>y</key>
                   <integer>475</integer>
                 </dict>
@@ -215,7 +215,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1310</string>
+                  <integer>-1310</integer>
                   <key>y</key>
                   <integer>562</integer>
                 </dict>
@@ -225,7 +225,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1442</string>
+                  <integer>-1442</integer>
                   <key>y</key>
                   <integer>562</integer>
                 </dict>
@@ -233,7 +233,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1574</string>
+                  <integer>-1574</integer>
                   <key>y</key>
                   <integer>562</integer>
                 </dict>
@@ -241,7 +241,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1680</string>
+                  <integer>-1680</integer>
                   <key>y</key>
                   <integer>463</integer>
                 </dict>
@@ -251,7 +251,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1680</string>
+                  <integer>-1680</integer>
                   <key>y</key>
                   <integer>274</integer>
                 </dict>
@@ -259,7 +259,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1680</string>
+                  <integer>-1680</integer>
                   <key>y</key>
                   <integer>102</integer>
                 </dict>
@@ -267,9 +267,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1591</string>
+                  <integer>-1591</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -277,25 +277,25 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1422</string>
+                  <integer>-1422</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1359</string>
+                  <integer>-1359</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1296</string>
+                  <integer>-1296</integer>
                   <key>y</key>
-                  <string>-1</string>
+                  <integer>-1</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -303,7 +303,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1239</string>
+                  <integer>-1239</integer>
                   <key>y</key>
                   <integer>28</integer>
                 </dict>
@@ -313,7 +313,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1259</string>
+                  <integer>-1259</integer>
                   <key>y</key>
                   <integer>78</integer>
                 </dict>
@@ -321,7 +321,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1312</string>
+                  <integer>-1312</integer>
                   <key>y</key>
                   <integer>54</integer>
                 </dict>
@@ -329,7 +329,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1367</string>
+                  <integer>-1367</integer>
                   <key>y</key>
                   <integer>37</integer>
                 </dict>
@@ -339,7 +339,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1422</string>
+                  <integer>-1422</integer>
                   <key>y</key>
                   <integer>37</integer>
                 </dict>
@@ -354,7 +354,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1639</string>
+                  <integer>-1639</integer>
                   <key>y</key>
                   <integer>289</integer>
                 </dict>
@@ -364,7 +364,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1270</string>
+                  <integer>-1270</integer>
                   <key>y</key>
                   <integer>289</integer>
                 </dict>
@@ -374,7 +374,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1270</string>
+                  <integer>-1270</integer>
                   <key>y</key>
                   <integer>343</integer>
                 </dict>
@@ -384,7 +384,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1639</string>
+                  <integer>-1639</integer>
                   <key>y</key>
                   <integer>343</integer>
                 </dict>
@@ -397,7 +397,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-999</string>
+                  <integer>-999</integer>
                   <key>y</key>
                   <integer>37</integer>
                 </dict>
@@ -405,7 +405,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1052</string>
+                  <integer>-1052</integer>
                   <key>y</key>
                   <integer>145</integer>
                 </dict>
@@ -415,7 +415,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1052</string>
+                  <integer>-1052</integer>
                   <key>y</key>
                   <integer>275</integer>
                 </dict>
@@ -423,7 +423,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1052</string>
+                  <integer>-1052</integer>
                   <key>y</key>
                   <integer>434</integer>
                 </dict>
@@ -431,7 +431,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-980</string>
+                  <integer>-980</integer>
                   <key>y</key>
                   <integer>508</integer>
                 </dict>
@@ -441,7 +441,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-870</string>
+                  <integer>-870</integer>
                   <key>y</key>
                   <integer>508</integer>
                 </dict>
@@ -449,7 +449,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-759</string>
+                  <integer>-759</integer>
                   <key>y</key>
                   <integer>508</integer>
                 </dict>
@@ -457,7 +457,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-709</string>
+                  <integer>-709</integer>
                   <key>y</key>
                   <integer>446</integer>
                 </dict>
@@ -467,7 +467,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-709</string>
+                  <integer>-709</integer>
                   <key>y</key>
                   <integer>310</integer>
                 </dict>
@@ -477,7 +477,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-709</string>
+                  <integer>-709</integer>
                   <key>y</key>
                   <integer>289</integer>
                 </dict>
@@ -487,7 +487,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-653</string>
+                  <integer>-653</integer>
                   <key>y</key>
                   <integer>289</integer>
                 </dict>
@@ -497,7 +497,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-653</string>
+                  <integer>-653</integer>
                   <key>y</key>
                   <integer>310</integer>
                 </dict>
@@ -505,7 +505,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-654</string>
+                  <integer>-654</integer>
                   <key>y</key>
                   <integer>475</integer>
                 </dict>
@@ -513,7 +513,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-738</string>
+                  <integer>-738</integer>
                   <key>y</key>
                   <integer>562</integer>
                 </dict>
@@ -523,7 +523,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-870</string>
+                  <integer>-870</integer>
                   <key>y</key>
                   <integer>562</integer>
                 </dict>
@@ -531,7 +531,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1002</string>
+                  <integer>-1002</integer>
                   <key>y</key>
                   <integer>562</integer>
                 </dict>
@@ -539,7 +539,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1108</string>
+                  <integer>-1108</integer>
                   <key>y</key>
                   <integer>463</integer>
                 </dict>
@@ -549,7 +549,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1108</string>
+                  <integer>-1108</integer>
                   <key>y</key>
                   <integer>274</integer>
                 </dict>
@@ -557,7 +557,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1108</string>
+                  <integer>-1108</integer>
                   <key>y</key>
                   <integer>102</integer>
                 </dict>
@@ -565,9 +565,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1019</string>
+                  <integer>-1019</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -575,25 +575,25 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-850</string>
+                  <integer>-850</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-787</string>
+                  <integer>-787</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-724</string>
+                  <integer>-724</integer>
                   <key>y</key>
-                  <string>-1</string>
+                  <integer>-1</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -601,7 +601,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-667</string>
+                  <integer>-667</integer>
                   <key>y</key>
                   <integer>28</integer>
                 </dict>
@@ -611,7 +611,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-687</string>
+                  <integer>-687</integer>
                   <key>y</key>
                   <integer>78</integer>
                 </dict>
@@ -619,7 +619,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-740</string>
+                  <integer>-740</integer>
                   <key>y</key>
                   <integer>54</integer>
                 </dict>
@@ -627,7 +627,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-795</string>
+                  <integer>-795</integer>
                   <key>y</key>
                   <integer>37</integer>
                 </dict>
@@ -637,7 +637,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-850</string>
+                  <integer>-850</integer>
                   <key>y</key>
                   <integer>37</integer>
                 </dict>
@@ -652,7 +652,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1067</string>
+                  <integer>-1067</integer>
                   <key>y</key>
                   <integer>289</integer>
                 </dict>
@@ -662,7 +662,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-698</string>
+                  <integer>-698</integer>
                   <key>y</key>
                   <integer>289</integer>
                 </dict>
@@ -672,7 +672,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-698</string>
+                  <integer>-698</integer>
                   <key>y</key>
                   <integer>343</integer>
                 </dict>
@@ -682,7 +682,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1067</string>
+                  <integer>-1067</integer>
                   <key>y</key>
                   <integer>343</integer>
                 </dict>
@@ -695,7 +695,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-320</string>
+                  <integer>-320</integer>
                   <key>y</key>
                   <integer>131</integer>
                 </dict>
@@ -703,7 +703,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-353</string>
+                  <integer>-353</integer>
                   <key>y</key>
                   <integer>175</integer>
                 </dict>
@@ -713,7 +713,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-353</string>
+                  <integer>-353</integer>
                   <key>y</key>
                   <integer>260</integer>
                 </dict>
@@ -723,7 +723,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-353</string>
+                  <integer>-353</integer>
                   <key>y</key>
                   <integer>324</integer>
                 </dict>
@@ -731,7 +731,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-353</string>
+                  <integer>-353</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -739,7 +739,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-319</string>
+                  <integer>-319</integer>
                   <key>y</key>
                   <integer>412</integer>
                 </dict>
@@ -749,7 +749,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-276</string>
+                  <integer>-276</integer>
                   <key>y</key>
                   <integer>412</integer>
                 </dict>
@@ -757,7 +757,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-233</string>
+                  <integer>-233</integer>
                   <key>y</key>
                   <integer>412</integer>
                 </dict>
@@ -765,7 +765,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-200</string>
+                  <integer>-200</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -775,7 +775,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-200</string>
+                  <integer>-200</integer>
                   <key>y</key>
                   <integer>324</integer>
                 </dict>
@@ -785,7 +785,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-200</string>
+                  <integer>-200</integer>
                   <key>y</key>
                   <integer>219</integer>
                 </dict>
@@ -795,7 +795,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-4</string>
+                  <integer>-4</integer>
                   <key>y</key>
                   <integer>219</integer>
                 </dict>
@@ -805,7 +805,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-4</string>
+                  <integer>-4</integer>
                   <key>y</key>
                   <integer>293</integer>
                 </dict>
@@ -813,7 +813,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-4</string>
+                  <integer>-4</integer>
                   <key>y</key>
                   <real>1.128</real>
                 </dict>
@@ -821,7 +821,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-126</string>
+                  <integer>-126</integer>
                   <key>y</key>
                   <integer>562</integer>
                 </dict>
@@ -831,7 +831,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-277</string>
+                  <integer>-277</integer>
                   <key>y</key>
                   <integer>562</integer>
                 </dict>
@@ -839,7 +839,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-427</string>
+                  <integer>-427</integer>
                   <key>y</key>
                   <integer>562</integer>
                 </dict>
@@ -847,7 +847,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-549</string>
+                  <integer>-549</integer>
                   <key>y</key>
                   <integer>468</integer>
                 </dict>
@@ -857,7 +857,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-549</string>
+                  <integer>-549</integer>
                   <key>y</key>
                   <integer>274</integer>
                 </dict>
@@ -865,7 +865,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-549</string>
+                  <integer>-549</integer>
                   <key>y</key>
                   <integer>102</integer>
                 </dict>
@@ -873,9 +873,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-454</string>
+                  <integer>-454</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -883,23 +883,23 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-246</string>
+                  <integer>-246</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-168</string>
+                  <integer>-168</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-90</string>
+                  <integer>-90</integer>
                   <key>y</key>
                   <integer>4</integer>
                 </dict>
@@ -909,7 +909,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-20</string>
+                  <integer>-20</integer>
                   <key>y</key>
                   <integer>46</integer>
                 </dict>
@@ -919,7 +919,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-75</string>
+                  <integer>-75</integer>
                   <key>y</key>
                   <integer>180</integer>
                 </dict>
@@ -927,7 +927,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-127</string>
+                  <integer>-127</integer>
                   <key>y</key>
                   <integer>151</integer>
                 </dict>
@@ -935,7 +935,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-176</string>
+                  <integer>-176</integer>
                   <key>y</key>
                   <integer>131</integer>
                 </dict>
@@ -945,7 +945,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-227</string>
+                  <integer>-227</integer>
                   <key>y</key>
                   <integer>131</integer>
                 </dict>
@@ -960,7 +960,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-458</string>
+                  <integer>-458</integer>
                   <key>y</key>
                   <integer>219</integer>
                 </dict>
@@ -970,7 +970,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-99</string>
+                  <integer>-99</integer>
                   <key>y</key>
                   <integer>219</integer>
                 </dict>
@@ -980,7 +980,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-99</string>
+                  <integer>-99</integer>
                   <key>y</key>
                   <integer>343</integer>
                 </dict>
@@ -990,7 +990,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-458</string>
+                  <integer>-458</integer>
                   <key>y</key>
                   <integer>343</integer>
                 </dict>
@@ -1173,7 +1173,7 @@
                   <key>x</key>
                   <integer>179</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -1183,7 +1183,7 @@
                   <key>x</key>
                   <integer>348</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -1191,7 +1191,7 @@
                   <key>x</key>
                   <integer>411</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -1199,7 +1199,7 @@
                   <key>x</key>
                   <integer>474</integer>
                   <key>y</key>
-                  <string>-1</string>
+                  <integer>-1</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>

--- a/Source Files/Biryani-Bold.ufo/glyphs/eC_andraM_atra-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/eC_andraM_atra-deva.glif
@@ -42,7 +42,7 @@
               <key>name</key>
               <string>top</string>
               <key>x</key>
-              <string>-138</string>
+              <integer>-138</integer>
               <key>y</key>
               <integer>784</integer>
             </dict>
@@ -50,7 +50,7 @@
               <key>name</key>
               <string>_top</string>
               <key>x</key>
-              <string>-138</string>
+              <integer>-138</integer>
               <key>y</key>
               <integer>634</integer>
             </dict>
@@ -67,7 +67,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-30</string>
+                  <integer>-30</integer>
                   <key>y</key>
                   <integer>710</integer>
                 </dict>
@@ -105,7 +105,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-3</string>
+                  <integer>-3</integer>
                   <key>y</key>
                   <integer>869</integer>
                 </dict>
@@ -115,7 +115,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-3</string>
+                  <integer>-3</integer>
                   <key>y</key>
                   <integer>859</integer>
                 </dict>
@@ -123,7 +123,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-3</string>
+                  <integer>-3</integer>
                   <key>y</key>
                   <integer>794</integer>
                 </dict>
@@ -131,7 +131,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-47</string>
+                  <integer>-47</integer>
                   <key>y</key>
                   <integer>754</integer>
                 </dict>
@@ -141,7 +141,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-138</string>
+                  <integer>-138</integer>
                   <key>y</key>
                   <integer>754</integer>
                 </dict>
@@ -149,7 +149,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-229</string>
+                  <integer>-229</integer>
                   <key>y</key>
                   <integer>754</integer>
                 </dict>
@@ -157,7 +157,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-273</string>
+                  <integer>-273</integer>
                   <key>y</key>
                   <integer>794</integer>
                 </dict>
@@ -167,7 +167,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-273</string>
+                  <integer>-273</integer>
                   <key>y</key>
                   <integer>859</integer>
                 </dict>
@@ -177,7 +177,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-273</string>
+                  <integer>-273</integer>
                   <key>y</key>
                   <integer>869</integer>
                 </dict>
@@ -187,7 +187,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-317</string>
+                  <integer>-317</integer>
                   <key>y</key>
                   <integer>869</integer>
                 </dict>
@@ -197,7 +197,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-317</string>
+                  <integer>-317</integer>
                   <key>y</key>
                   <integer>859</integer>
                 </dict>
@@ -205,7 +205,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-317</string>
+                  <integer>-317</integer>
                   <key>y</key>
                   <integer>764</integer>
                 </dict>
@@ -213,7 +213,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-246</string>
+                  <integer>-246</integer>
                   <key>y</key>
                   <integer>710</integer>
                 </dict>
@@ -223,7 +223,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-138</string>
+                  <integer>-138</integer>
                   <key>y</key>
                   <integer>710</integer>
                 </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/eM_atra-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/eM_atra-deva.glif
@@ -36,7 +36,7 @@
               <key>name</key>
               <string>top</string>
               <key>x</key>
-              <string>-42</string>
+              <integer>-42</integer>
               <key>y</key>
               <integer>634</integer>
             </dict>
@@ -44,7 +44,7 @@
               <key>name</key>
               <string>_top</string>
               <key>x</key>
-              <string>-138</string>
+              <integer>-138</integer>
               <key>y</key>
               <integer>634</integer>
             </dict>
@@ -63,7 +63,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-109</string>
+                  <integer>-109</integer>
                   <key>y</key>
                   <integer>624</integer>
                 </dict>
@@ -73,7 +73,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-142</string>
+                  <integer>-142</integer>
                   <key>y</key>
                   <integer>769</integer>
                 </dict>
@@ -81,7 +81,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-168</string>
+                  <integer>-168</integer>
                   <key>y</key>
                   <integer>884</integer>
                 </dict>
@@ -89,7 +89,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-217</string>
+                  <integer>-217</integer>
                   <key>y</key>
                   <integer>903</integer>
                 </dict>
@@ -99,7 +99,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-317</string>
+                  <integer>-317</integer>
                   <key>y</key>
                   <integer>903</integer>
                 </dict>
@@ -109,7 +109,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-392</string>
+                  <integer>-392</integer>
                   <key>y</key>
                   <integer>903</integer>
                 </dict>
@@ -119,7 +119,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-392</string>
+                  <integer>-392</integer>
                   <key>y</key>
                   <integer>859</integer>
                 </dict>
@@ -129,7 +129,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-317</string>
+                  <integer>-317</integer>
                   <key>y</key>
                   <integer>859</integer>
                 </dict>
@@ -137,7 +137,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-245</string>
+                  <integer>-245</integer>
                   <key>y</key>
                   <integer>859</integer>
                 </dict>
@@ -145,7 +145,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-212</string>
+                  <integer>-212</integer>
                   <key>y</key>
                   <integer>841</integer>
                 </dict>
@@ -155,7 +155,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-196</string>
+                  <integer>-196</integer>
                   <key>y</key>
                   <integer>769</integer>
                 </dict>
@@ -165,7 +165,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-163</string>
+                  <integer>-163</integer>
                   <key>y</key>
                   <integer>624</integer>
                 </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/eS_hortM_atra-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/eS_hortM_atra-deva.glif
@@ -41,7 +41,7 @@
               <key>name</key>
               <string>_top</string>
               <key>x</key>
-              <string>-138</string>
+              <integer>-138</integer>
               <key>y</key>
               <integer>634</integer>
             </dict>
@@ -58,7 +58,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-591</string>
+                  <integer>-591</integer>
                   <key>y</key>
                   <integer>837</integer>
                 </dict>
@@ -66,7 +66,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-600</string>
+                  <integer>-600</integer>
                   <key>y</key>
                   <integer>875</integer>
                 </dict>
@@ -76,7 +76,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-600</string>
+                  <integer>-600</integer>
                   <key>y</key>
                   <integer>956</integer>
                 </dict>
@@ -86,7 +86,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-600</string>
+                  <integer>-600</integer>
                   <key>y</key>
                   <integer>971</integer>
                 </dict>
@@ -96,7 +96,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-654</string>
+                  <integer>-654</integer>
                   <key>y</key>
                   <integer>971</integer>
                 </dict>
@@ -106,7 +106,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-654</string>
+                  <integer>-654</integer>
                   <key>y</key>
                   <integer>956</integer>
                 </dict>
@@ -114,7 +114,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-654</string>
+                  <integer>-654</integer>
                   <key>y</key>
                   <integer>844</integer>
                 </dict>
@@ -122,7 +122,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-614</string>
+                  <integer>-614</integer>
                   <key>y</key>
                   <integer>793</integer>
                 </dict>
@@ -132,7 +132,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-463</string>
+                  <integer>-463</integer>
                   <key>y</key>
                   <integer>793</integer>
                 </dict>
@@ -142,7 +142,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-296</string>
+                  <integer>-296</integer>
                   <key>y</key>
                   <integer>793</integer>
                 </dict>
@@ -150,7 +150,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-181</string>
+                  <integer>-181</integer>
                   <key>y</key>
                   <integer>793</integer>
                 </dict>
@@ -158,7 +158,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-164</string>
+                  <integer>-164</integer>
                   <key>y</key>
                   <integer>755</integer>
                 </dict>
@@ -168,7 +168,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-164</string>
+                  <integer>-164</integer>
                   <key>y</key>
                   <integer>674</integer>
                 </dict>
@@ -178,7 +178,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-164</string>
+                  <integer>-164</integer>
                   <key>y</key>
                   <integer>624</integer>
                 </dict>
@@ -188,7 +188,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-110</string>
+                  <integer>-110</integer>
                   <key>y</key>
                   <integer>624</integer>
                 </dict>
@@ -198,7 +198,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-110</string>
+                  <integer>-110</integer>
                   <key>y</key>
                   <integer>674</integer>
                 </dict>
@@ -206,7 +206,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-110</string>
+                  <integer>-110</integer>
                   <key>y</key>
                   <integer>786</integer>
                 </dict>
@@ -214,7 +214,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-138</string>
+                  <integer>-138</integer>
                   <key>y</key>
                   <integer>837</integer>
                 </dict>
@@ -224,7 +224,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-296</string>
+                  <integer>-296</integer>
                   <key>y</key>
                   <integer>837</integer>
                 </dict>
@@ -234,7 +234,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-463</string>
+                  <integer>-463</integer>
                   <key>y</key>
                   <integer>837</integer>
                 </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/eth.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/eth.glif
@@ -67,7 +67,7 @@
                   <key>x</key>
                   <integer>496</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -329,7 +329,7 @@
                   <key>x</key>
                   <integer>191</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -339,7 +339,7 @@
                   <key>x</key>
                   <integer>337</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
               </array>
             </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/euro.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/euro.glif
@@ -101,7 +101,7 @@
                   <key>x</key>
                   <integer>185</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -111,7 +111,7 @@
                   <key>x</key>
                   <integer>325</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -119,7 +119,7 @@
                   <key>x</key>
                   <integer>385</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -127,7 +127,7 @@
                   <key>x</key>
                   <integer>424</integer>
                   <key>y</key>
-                  <string>-4</string>
+                  <integer>-4</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>

--- a/Source Files/Biryani-Bold.ufo/glyphs/five.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/five.glif
@@ -157,7 +157,7 @@
                   <key>x</key>
                   <integer>386</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -359,7 +359,7 @@
                   <key>x</key>
                   <integer>132</integer>
                   <key>y</key>
-                  <string>-8</string>
+                  <integer>-8</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -367,7 +367,7 @@
                   <key>x</key>
                   <integer>186</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -377,7 +377,7 @@
                   <key>x</key>
                   <integer>240</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
               </array>
             </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/florin.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/florin.glif
@@ -79,7 +79,7 @@
                   <key>x</key>
                   <integer>73</integer>
                   <key>y</key>
-                  <string>-234</string>
+                  <integer>-234</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -89,7 +89,7 @@
                   <key>x</key>
                   <integer>247</integer>
                   <key>y</key>
-                  <string>-234</string>
+                  <integer>-234</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>

--- a/Source Files/Biryani-Bold.ufo/glyphs/g-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/g-deva.glif
@@ -199,7 +199,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -209,7 +209,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/g.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/g.glif
@@ -84,7 +84,7 @@
                   <key>x</key>
                   <integer>499</integer>
                   <key>y</key>
-                  <string>-251</string>
+                  <integer>-251</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -92,7 +92,7 @@
                   <key>x</key>
                   <integer>526</integer>
                   <key>y</key>
-                  <string>-150</string>
+                  <integer>-150</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -102,7 +102,7 @@
                   <key>x</key>
                   <integer>526</integer>
                   <key>y</key>
-                  <string>-18</string>
+                  <integer>-18</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -132,7 +132,7 @@
                   <key>x</key>
                   <integer>472</integer>
                   <key>y</key>
-                  <string>-8</string>
+                  <integer>-8</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -140,7 +140,7 @@
                   <key>x</key>
                   <integer>472</integer>
                   <key>y</key>
-                  <string>-126</string>
+                  <integer>-126</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -148,7 +148,7 @@
                   <key>x</key>
                   <integer>462</integer>
                   <key>y</key>
-                  <string>-197</string>
+                  <integer>-197</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -158,7 +158,7 @@
                   <key>x</key>
                   <integer>288</integer>
                   <key>y</key>
-                  <string>-197</string>
+                  <integer>-197</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -166,7 +166,7 @@
                   <key>x</key>
                   <integer>235</integer>
                   <key>y</key>
-                  <string>-197</string>
+                  <integer>-197</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -174,7 +174,7 @@
                   <key>x</key>
                   <integer>178</integer>
                   <key>y</key>
-                  <string>-181</string>
+                  <integer>-181</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -184,7 +184,7 @@
                   <key>x</key>
                   <integer>124</integer>
                   <key>y</key>
-                  <string>-155</string>
+                  <integer>-155</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -194,7 +194,7 @@
                   <key>x</key>
                   <integer>124</integer>
                   <key>y</key>
-                  <string>-215</string>
+                  <integer>-215</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -202,7 +202,7 @@
                   <key>x</key>
                   <integer>185</integer>
                   <key>y</key>
-                  <string>-241</string>
+                  <integer>-241</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -210,7 +210,7 @@
                   <key>x</key>
                   <integer>229</integer>
                   <key>y</key>
-                  <string>-251</string>
+                  <integer>-251</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -220,7 +220,7 @@
                   <key>x</key>
                   <integer>303</integer>
                   <key>y</key>
-                  <string>-251</string>
+                  <integer>-251</integer>
                 </dict>
               </array>
             </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/germandbls.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/germandbls.glif
@@ -294,7 +294,7 @@
                   <key>x</key>
                   <integer>321</integer>
                   <key>y</key>
-                  <string>-11</string>
+                  <integer>-11</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -302,7 +302,7 @@
                   <key>x</key>
                   <integer>356</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -312,7 +312,7 @@
                   <key>x</key>
                   <integer>396</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -320,7 +320,7 @@
                   <key>x</key>
                   <integer>502</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>

--- a/Source Files/Biryani-Bold.ufo/glyphs/h.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/h.glif
@@ -100,7 +100,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-941</string>
+                  <integer>-941</integer>
                   <key>y</key>
                   <integer>558</integer>
                 </dict>
@@ -108,7 +108,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1018</string>
+                  <integer>-1018</integer>
                   <key>y</key>
                   <integer>509</integer>
                 </dict>
@@ -118,7 +118,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1068</string>
+                  <integer>-1068</integer>
                   <key>y</key>
                   <integer>451</integer>
                 </dict>
@@ -128,7 +128,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1068</string>
+                  <integer>-1068</integer>
                   <key>y</key>
                   <integer>397</integer>
                 </dict>
@@ -136,7 +136,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1017</string>
+                  <integer>-1017</integer>
                   <key>y</key>
                   <integer>456</integer>
                 </dict>
@@ -144,7 +144,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-945</string>
+                  <integer>-945</integer>
                   <key>y</key>
                   <integer>504</integer>
                 </dict>
@@ -154,7 +154,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-866</string>
+                  <integer>-866</integer>
                   <key>y</key>
                   <integer>504</integer>
                 </dict>
@@ -162,7 +162,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-764</string>
+                  <integer>-764</integer>
                   <key>y</key>
                   <integer>504</integer>
                 </dict>
@@ -170,7 +170,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-731</string>
+                  <integer>-731</integer>
                   <key>y</key>
                   <integer>458</integer>
                 </dict>
@@ -180,7 +180,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-731</string>
+                  <integer>-731</integer>
                   <key>y</key>
                   <integer>330</integer>
                 </dict>
@@ -190,7 +190,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-731</string>
+                  <integer>-731</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -200,7 +200,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-677</string>
+                  <integer>-677</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -210,7 +210,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-677</string>
+                  <integer>-677</integer>
                   <key>y</key>
                   <integer>330</integer>
                 </dict>
@@ -218,7 +218,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-677</string>
+                  <integer>-677</integer>
                   <key>y</key>
                   <integer>499</integer>
                 </dict>
@@ -226,7 +226,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-740</string>
+                  <integer>-740</integer>
                   <key>y</key>
                   <integer>558</integer>
                 </dict>
@@ -236,7 +236,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-866</string>
+                  <integer>-866</integer>
                   <key>y</key>
                   <integer>558</integer>
                 </dict>
@@ -251,7 +251,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1094</string>
+                  <integer>-1094</integer>
                   <key>y</key>
                   <integer>546</integer>
                 </dict>
@@ -261,7 +261,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1094</string>
+                  <integer>-1094</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -271,7 +271,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1040</string>
+                  <integer>-1040</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -281,7 +281,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1040</string>
+                  <integer>-1040</integer>
                   <key>y</key>
                   <integer>546</integer>
                 </dict>
@@ -294,7 +294,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-329</string>
+                  <integer>-329</integer>
                   <key>y</key>
                   <integer>558</integer>
                 </dict>
@@ -302,7 +302,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-406</string>
+                  <integer>-406</integer>
                   <key>y</key>
                   <integer>509</integer>
                 </dict>
@@ -312,7 +312,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-456</string>
+                  <integer>-456</integer>
                   <key>y</key>
                   <integer>451</integer>
                 </dict>
@@ -322,7 +322,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-456</string>
+                  <integer>-456</integer>
                   <key>y</key>
                   <integer>397</integer>
                 </dict>
@@ -330,7 +330,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-405</string>
+                  <integer>-405</integer>
                   <key>y</key>
                   <integer>456</integer>
                 </dict>
@@ -338,7 +338,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-333</string>
+                  <integer>-333</integer>
                   <key>y</key>
                   <integer>504</integer>
                 </dict>
@@ -348,7 +348,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-254</string>
+                  <integer>-254</integer>
                   <key>y</key>
                   <integer>504</integer>
                 </dict>
@@ -356,7 +356,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-152</string>
+                  <integer>-152</integer>
                   <key>y</key>
                   <integer>504</integer>
                 </dict>
@@ -364,7 +364,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-119</string>
+                  <integer>-119</integer>
                   <key>y</key>
                   <integer>458</integer>
                 </dict>
@@ -374,7 +374,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-119</string>
+                  <integer>-119</integer>
                   <key>y</key>
                   <integer>330</integer>
                 </dict>
@@ -384,7 +384,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-119</string>
+                  <integer>-119</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -394,7 +394,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-65</string>
+                  <integer>-65</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -404,7 +404,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-65</string>
+                  <integer>-65</integer>
                   <key>y</key>
                   <integer>330</integer>
                 </dict>
@@ -412,7 +412,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-65</string>
+                  <integer>-65</integer>
                   <key>y</key>
                   <integer>499</integer>
                 </dict>
@@ -420,7 +420,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-128</string>
+                  <integer>-128</integer>
                   <key>y</key>
                   <integer>558</integer>
                 </dict>
@@ -430,7 +430,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-254</string>
+                  <integer>-254</integer>
                   <key>y</key>
                   <integer>558</integer>
                 </dict>
@@ -445,7 +445,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-482</string>
+                  <integer>-482</integer>
                   <key>y</key>
                   <integer>846</integer>
                 </dict>
@@ -455,7 +455,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-482</string>
+                  <integer>-482</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -465,7 +465,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-428</string>
+                  <integer>-428</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -475,7 +475,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-428</string>
+                  <integer>-428</integer>
                   <key>y</key>
                   <integer>846</integer>
                 </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/h_na-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/h_na-deva.glif
@@ -188,7 +188,7 @@
                   <key>x</key>
                   <integer>259</integer>
                   <key>y</key>
-                  <string>-69</string>
+                  <integer>-69</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -196,7 +196,7 @@
                   <key>x</key>
                   <integer>293</integer>
                   <key>y</key>
-                  <string>-117</string>
+                  <integer>-117</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -206,7 +206,7 @@
                   <key>x</key>
                   <integer>394</integer>
                   <key>y</key>
-                  <string>-154</string>
+                  <integer>-154</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -216,7 +216,7 @@
                   <key>x</key>
                   <integer>457</integer>
                   <key>y</key>
-                  <string>-51</string>
+                  <integer>-51</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -224,7 +224,7 @@
                   <key>x</key>
                   <integer>421</integer>
                   <key>y</key>
-                  <string>-38</string>
+                  <integer>-38</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -232,7 +232,7 @@
                   <key>x</key>
                   <integer>404</integer>
                   <key>y</key>
-                  <string>-19</string>
+                  <integer>-19</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>

--- a/Source Files/Biryani-Bold.ufo/glyphs/ha_uM_atra-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/ha_uM_atra-deva.glif
@@ -110,7 +110,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>674</integer>
                 </dict>
@@ -120,7 +120,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>550</integer>
                 </dict>
@@ -526,7 +526,7 @@
                   <key>x</key>
                   <integer>272</integer>
                   <key>y</key>
-                  <string>-44</string>
+                  <integer>-44</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -536,7 +536,7 @@
                   <key>x</key>
                   <integer>328</integer>
                   <key>y</key>
-                  <string>-56</string>
+                  <integer>-56</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -552,7 +552,7 @@
                   <key>x</key>
                   <integer>409</integer>
                   <key>y</key>
-                  <string>-79</string>
+                  <integer>-79</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -562,7 +562,7 @@
                   <key>x</key>
                   <integer>409</integer>
                   <key>y</key>
-                  <string>-110</string>
+                  <integer>-110</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -570,7 +570,7 @@
                   <key>x</key>
                   <integer>409</integer>
                   <key>y</key>
-                  <string>-141</string>
+                  <integer>-141</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -578,7 +578,7 @@
                   <key>x</key>
                   <integer>379</integer>
                   <key>y</key>
-                  <string>-155</string>
+                  <integer>-155</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -588,7 +588,7 @@
                   <key>x</key>
                   <integer>322</integer>
                   <key>y</key>
-                  <string>-155</string>
+                  <integer>-155</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -596,7 +596,7 @@
                   <key>x</key>
                   <integer>213</integer>
                   <key>y</key>
-                  <string>-155</string>
+                  <integer>-155</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -604,7 +604,7 @@
                   <key>x</key>
                   <integer>133</integer>
                   <key>y</key>
-                  <string>-105</string>
+                  <integer>-105</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -614,7 +614,7 @@
                   <key>x</key>
                   <integer>61</integer>
                   <key>y</key>
-                  <string>-40</string>
+                  <integer>-40</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -622,9 +622,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-21</string>
+                  <integer>-21</integer>
                   <key>y</key>
-                  <string>-135</string>
+                  <integer>-135</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -632,7 +632,7 @@
                   <key>x</key>
                   <integer>54</integer>
                   <key>y</key>
-                  <string>-207</string>
+                  <integer>-207</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -640,7 +640,7 @@
                   <key>x</key>
                   <integer>172</integer>
                   <key>y</key>
-                  <string>-279</string>
+                  <integer>-279</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -650,7 +650,7 @@
                   <key>x</key>
                   <integer>332</integer>
                   <key>y</key>
-                  <string>-279</string>
+                  <integer>-279</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -658,7 +658,7 @@
                   <key>x</key>
                   <integer>469</integer>
                   <key>y</key>
-                  <string>-279</string>
+                  <integer>-279</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -676,7 +676,7 @@
                   <key>x</key>
                   <integer>563</integer>
                   <key>y</key>
-                  <string>-98</string>
+                  <integer>-98</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>

--- a/Source Files/Biryani-Bold.ufo/glyphs/i-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/i-deva.glif
@@ -102,7 +102,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-255</string>
+                  <integer>-255</integer>
                   <key>y</key>
                   <integer>470</integer>
                 </dict>
@@ -110,7 +110,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-351</string>
+                  <integer>-351</integer>
                   <key>y</key>
                   <integer>470</integer>
                 </dict>
@@ -118,7 +118,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-399</string>
+                  <integer>-399</integer>
                   <key>y</key>
                   <integer>440</integer>
                 </dict>
@@ -128,7 +128,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-399</string>
+                  <integer>-399</integer>
                   <key>y</key>
                   <integer>358</integer>
                 </dict>
@@ -136,7 +136,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-399</string>
+                  <integer>-399</integer>
                   <key>y</key>
                   <integer>304</integer>
                 </dict>
@@ -144,7 +144,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-362</string>
+                  <integer>-362</integer>
                   <key>y</key>
                   <integer>262</integer>
                 </dict>
@@ -154,7 +154,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-341</string>
+                  <integer>-341</integer>
                   <key>y</key>
                   <integer>246</integer>
                 </dict>
@@ -164,7 +164,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-185</string>
+                  <integer>-185</integer>
                   <key>y</key>
                   <integer>246</integer>
                 </dict>
@@ -172,7 +172,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-116</string>
+                  <integer>-116</integer>
                   <key>y</key>
                   <integer>246</integer>
                 </dict>
@@ -180,7 +180,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-77</string>
+                  <integer>-77</integer>
                   <key>y</key>
                   <integer>224</integer>
                 </dict>
@@ -190,7 +190,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-75</string>
+                  <integer>-75</integer>
                   <key>y</key>
                   <integer>157</integer>
                 </dict>
@@ -198,7 +198,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-73</string>
+                  <integer>-73</integer>
                   <key>y</key>
                   <integer>94</integer>
                 </dict>
@@ -206,7 +206,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-116</string>
+                  <integer>-116</integer>
                   <key>y</key>
                   <integer>67</integer>
                 </dict>
@@ -216,7 +216,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-185</string>
+                  <integer>-185</integer>
                   <key>y</key>
                   <integer>67</integer>
                 </dict>
@@ -226,7 +226,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-200</string>
+                  <integer>-200</integer>
                   <key>y</key>
                   <integer>67</integer>
                 </dict>
@@ -234,7 +234,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-268</string>
+                  <integer>-268</integer>
                   <key>y</key>
                   <integer>67</integer>
                 </dict>
@@ -242,7 +242,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-317</string>
+                  <integer>-317</integer>
                   <key>y</key>
                   <integer>85</integer>
                 </dict>
@@ -252,7 +252,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-364</string>
+                  <integer>-364</integer>
                   <key>y</key>
                   <integer>115</integer>
                 </dict>
@@ -262,7 +262,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-382</string>
+                  <integer>-382</integer>
                   <key>y</key>
                   <integer>73</integer>
                 </dict>
@@ -270,7 +270,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-332</string>
+                  <integer>-332</integer>
                   <key>y</key>
                   <integer>42</integer>
                 </dict>
@@ -278,7 +278,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-276</string>
+                  <integer>-276</integer>
                   <key>y</key>
                   <integer>23</integer>
                 </dict>
@@ -288,7 +288,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-200</string>
+                  <integer>-200</integer>
                   <key>y</key>
                   <integer>23</integer>
                 </dict>
@@ -298,7 +298,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-185</string>
+                  <integer>-185</integer>
                   <key>y</key>
                   <integer>23</integer>
                 </dict>
@@ -306,7 +306,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-83</string>
+                  <integer>-83</integer>
                   <key>y</key>
                   <integer>23</integer>
                 </dict>
@@ -314,7 +314,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-21</string>
+                  <integer>-21</integer>
                   <key>y</key>
                   <integer>69</integer>
                 </dict>
@@ -324,7 +324,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-21</string>
+                  <integer>-21</integer>
                   <key>y</key>
                   <integer>157</integer>
                 </dict>
@@ -332,7 +332,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-21</string>
+                  <integer>-21</integer>
                   <key>y</key>
                   <integer>248</integer>
                 </dict>
@@ -340,7 +340,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-83</string>
+                  <integer>-83</integer>
                   <key>y</key>
                   <integer>290</integer>
                 </dict>
@@ -350,7 +350,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-185</string>
+                  <integer>-185</integer>
                   <key>y</key>
                   <integer>290</integer>
                 </dict>
@@ -360,7 +360,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-315</string>
+                  <integer>-315</integer>
                   <key>y</key>
                   <integer>290</integer>
                 </dict>
@@ -368,7 +368,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-330</string>
+                  <integer>-330</integer>
                   <key>y</key>
                   <integer>300</integer>
                 </dict>
@@ -376,7 +376,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-345</string>
+                  <integer>-345</integer>
                   <key>y</key>
                   <integer>323</integer>
                 </dict>
@@ -386,7 +386,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-345</string>
+                  <integer>-345</integer>
                   <key>y</key>
                   <integer>358</integer>
                 </dict>
@@ -394,7 +394,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-345</string>
+                  <integer>-345</integer>
                   <key>y</key>
                   <integer>412</integer>
                 </dict>
@@ -402,7 +402,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-313</string>
+                  <integer>-313</integer>
                   <key>y</key>
                   <integer>426</integer>
                 </dict>
@@ -412,7 +412,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-255</string>
+                  <integer>-255</integer>
                   <key>y</key>
                   <integer>426</integer>
                 </dict>
@@ -422,7 +422,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-91</string>
+                  <integer>-91</integer>
                   <key>y</key>
                   <integer>426</integer>
                 </dict>
@@ -432,7 +432,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-91</string>
+                  <integer>-91</integer>
                   <key>y</key>
                   <integer>470</integer>
                 </dict>
@@ -447,7 +447,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-399</string>
+                  <integer>-399</integer>
                   <key>y</key>
                   <integer>174</integer>
                 </dict>
@@ -457,9 +457,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-399</string>
+                  <integer>-399</integer>
                   <key>y</key>
-                  <string>-55</string>
+                  <integer>-55</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -467,9 +467,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-345</string>
+                  <integer>-345</integer>
                   <key>y</key>
-                  <string>-55</string>
+                  <integer>-55</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -477,7 +477,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-345</string>
+                  <integer>-345</integer>
                   <key>y</key>
                   <integer>174</integer>
                 </dict>
@@ -492,7 +492,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-482</string>
+                  <integer>-482</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -502,7 +502,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-482</string>
+                  <integer>-482</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -512,7 +512,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-145</string>
+                  <integer>-145</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -522,7 +522,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-145</string>
+                  <integer>-145</integer>
                   <key>y</key>
                   <integer>440</integer>
                 </dict>
@@ -532,7 +532,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-91</string>
+                  <integer>-91</integer>
                   <key>y</key>
                   <integer>440</integer>
                 </dict>
@@ -542,7 +542,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-91</string>
+                  <integer>-91</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -934,7 +934,7 @@
                   <key>x</key>
                   <integer>103</integer>
                   <key>y</key>
-                  <string>-55</string>
+                  <integer>-55</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -944,7 +944,7 @@
                   <key>x</key>
                   <integer>157</integer>
                   <key>y</key>
-                  <string>-55</string>
+                  <integer>-55</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>

--- a/Source Files/Biryani-Bold.ufo/glyphs/iM_atra-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/iM_atra-deva.glif
@@ -333,7 +333,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-11</string>
+                  <integer>-11</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -343,7 +343,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-11</string>
+                  <integer>-11</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -423,7 +423,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-11</string>
+                  <integer>-11</integer>
                   <key>y</key>
                   <integer>674</integer>
                 </dict>
@@ -433,7 +433,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-11</string>
+                  <integer>-11</integer>
                   <key>y</key>
                   <integer>550</integer>
                 </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/iiM_atra-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/iiM_atra-deva.glif
@@ -56,7 +56,7 @@
               <key>name</key>
               <string>iimatra</string>
               <key>x</key>
-              <string>-164</string>
+              <integer>-164</integer>
               <key>y</key>
               <integer>608</integer>
             </dict>
@@ -97,7 +97,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-119</string>
+                  <integer>-119</integer>
                   <key>y</key>
                   <integer>923</integer>
                 </dict>
@@ -105,7 +105,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-164</string>
+                  <integer>-164</integer>
                   <key>y</key>
                   <integer>876</integer>
                 </dict>
@@ -115,7 +115,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-164</string>
+                  <integer>-164</integer>
                   <key>y</key>
                   <integer>725</integer>
                 </dict>
@@ -125,7 +125,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-164</string>
+                  <integer>-164</integer>
                   <key>y</key>
                   <integer>608</integer>
                 </dict>
@@ -135,7 +135,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-110</string>
+                  <integer>-110</integer>
                   <key>y</key>
                   <integer>608</integer>
                 </dict>
@@ -145,7 +145,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-110</string>
+                  <integer>-110</integer>
                   <key>y</key>
                   <integer>725</integer>
                 </dict>
@@ -153,7 +153,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-110</string>
+                  <integer>-110</integer>
                   <key>y</key>
                   <integer>865</integer>
                 </dict>
@@ -161,7 +161,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-74</string>
+                  <integer>-74</integer>
                   <key>y</key>
                   <integer>879</integer>
                 </dict>
@@ -171,7 +171,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-11</string>
+                  <integer>-11</integer>
                   <key>y</key>
                   <integer>879</integer>
                 </dict>
@@ -273,7 +273,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-11</string>
+                  <integer>-11</integer>
                   <key>y</key>
                   <integer>923</integer>
                 </dict>
@@ -333,7 +333,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -363,7 +363,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -423,7 +423,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>674</integer>
                 </dict>
@@ -433,7 +433,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>550</integer>
                 </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/j-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/j-deva.glif
@@ -58,7 +58,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -68,7 +68,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/ja_halant_nya_halant-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/ja_halant_nya_halant-deva.glif
@@ -72,7 +72,7 @@
               <key>x</key>
               <integer>267</integer>
               <key>y</key>
-              <string>-62</string>
+              <integer>-62</integer>
             </dict>
           </array>
           <key>components</key>
@@ -446,7 +446,7 @@
                   <key>x</key>
                   <integer>73</integer>
                   <key>y</key>
-                  <string>-35</string>
+                  <integer>-35</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -456,7 +456,7 @@
                   <key>x</key>
                   <integer>127</integer>
                   <key>y</key>
-                  <string>-35</string>
+                  <integer>-35</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -479,7 +479,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -489,7 +489,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/jh_r-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/jh_r-deva.glif
@@ -513,7 +513,7 @@
                   <key>x</key>
                   <integer>73</integer>
                   <key>y</key>
-                  <string>-35</string>
+                  <integer>-35</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -523,7 +523,7 @@
                   <key>x</key>
                   <integer>127</integer>
                   <key>y</key>
-                  <string>-35</string>
+                  <integer>-35</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -546,7 +546,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -556,7 +556,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -688,7 +688,7 @@
                   <key>x</key>
                   <integer>453</integer>
                   <key>y</key>
-                  <string>-16</string>
+                  <integer>-16</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>

--- a/Source Files/Biryani-Bold.ufo/glyphs/jh_ra-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/jh_ra-deva.glif
@@ -522,7 +522,7 @@
                   <key>x</key>
                   <integer>73</integer>
                   <key>y</key>
-                  <string>-35</string>
+                  <integer>-35</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -532,7 +532,7 @@
                   <key>x</key>
                   <integer>127</integer>
                   <key>y</key>
-                  <string>-35</string>
+                  <integer>-35</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -555,7 +555,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -565,7 +565,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -697,7 +697,7 @@
                   <key>x</key>
                   <integer>453</integer>
                   <key>y</key>
-                  <string>-16</string>
+                  <integer>-16</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>

--- a/Source Files/Biryani-Bold.ufo/glyphs/jha-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/jha-deva.glif
@@ -95,7 +95,7 @@
               <key>x</key>
               <integer>267</integer>
               <key>y</key>
-              <string>-62</string>
+              <integer>-62</integer>
             </dict>
             <dict>
               <key>name</key>
@@ -530,7 +530,7 @@
                   <key>x</key>
                   <integer>73</integer>
                   <key>y</key>
-                  <string>-35</string>
+                  <integer>-35</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -540,7 +540,7 @@
                   <key>x</key>
                   <integer>127</integer>
                   <key>y</key>
-                  <string>-35</string>
+                  <integer>-35</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -563,7 +563,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -573,7 +573,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/k-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/k-deva.glif
@@ -350,7 +350,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -360,7 +360,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/k.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/k.glif
@@ -80,7 +80,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-40</string>
+                  <integer>-40</integer>
                   <key>y</key>
                   <integer>546</integer>
                 </dict>
@@ -90,7 +90,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-112</string>
+                  <integer>-112</integer>
                   <key>y</key>
                   <integer>546</integer>
                 </dict>
@@ -100,7 +100,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-371</string>
+                  <integer>-371</integer>
                   <key>y</key>
                   <integer>285</integer>
                 </dict>
@@ -110,7 +110,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-371</string>
+                  <integer>-371</integer>
                   <key>y</key>
                   <integer>213</integer>
                 </dict>
@@ -125,7 +125,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-417</string>
+                  <integer>-417</integer>
                   <key>y</key>
                   <integer>846</integer>
                 </dict>
@@ -135,7 +135,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-417</string>
+                  <integer>-417</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -145,7 +145,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-363</string>
+                  <integer>-363</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -155,7 +155,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-363</string>
+                  <integer>-363</integer>
                   <key>y</key>
                   <integer>846</integer>
                 </dict>
@@ -170,7 +170,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-307</string>
+                  <integer>-307</integer>
                   <key>y</key>
                   <integer>303</integer>
                 </dict>
@@ -180,7 +180,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-68</string>
+                  <integer>-68</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -200,7 +200,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-268</string>
+                  <integer>-268</integer>
                   <key>y</key>
                   <integer>340</integer>
                 </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/k_ss-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/k_ss-deva.glif
@@ -419,7 +419,7 @@
                   <key>x</key>
                   <integer>376</integer>
                   <key>y</key>
-                  <string>-55</string>
+                  <integer>-55</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -449,7 +449,7 @@
                   <key>x</key>
                   <integer>322</integer>
                   <key>y</key>
-                  <string>-55</string>
+                  <integer>-55</integer>
                 </dict>
               </array>
             </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/k_ss_r-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/k_ss_r-deva.glif
@@ -426,7 +426,7 @@
                   <key>x</key>
                   <integer>376</integer>
                   <key>y</key>
-                  <string>-55</string>
+                  <integer>-55</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -456,7 +456,7 @@
                   <key>x</key>
                   <integer>322</integer>
                   <key>y</key>
-                  <string>-55</string>
+                  <integer>-55</integer>
                 </dict>
               </array>
             </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/k_ss_ra-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/k_ss_ra-deva.glif
@@ -116,7 +116,7 @@
                   <key>x</key>
                   <integer>376</integer>
                   <key>y</key>
-                  <string>-55</string>
+                  <integer>-55</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -146,7 +146,7 @@
                   <key>x</key>
                   <integer>322</integer>
                   <key>y</key>
-                  <string>-55</string>
+                  <integer>-55</integer>
                 </dict>
               </array>
             </dict>
@@ -301,7 +301,7 @@
                   <key>x</key>
                   <integer>460</integer>
                   <key>y</key>
-                  <string>-16</string>
+                  <integer>-16</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>

--- a/Source Files/Biryani-Bold.ufo/glyphs/k_ssa-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/k_ssa-deva.glif
@@ -435,7 +435,7 @@
                   <key>x</key>
                   <integer>376</integer>
                   <key>y</key>
-                  <string>-55</string>
+                  <integer>-55</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -465,7 +465,7 @@
                   <key>x</key>
                   <integer>322</integer>
                   <key>y</key>
-                  <string>-55</string>
+                  <integer>-55</integer>
                 </dict>
               </array>
             </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/k_ta-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/k_ta-deva.glif
@@ -94,7 +94,7 @@
               <key>x</key>
               <integer>188</integer>
               <key>y</key>
-              <string>-103</string>
+              <integer>-103</integer>
             </dict>
             <dict>
               <key>name</key>

--- a/Source Files/Biryani-Bold.ufo/glyphs/ka-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/ka-deva.glif
@@ -156,7 +156,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-775</string>
+                  <integer>-775</integer>
                   <key>y</key>
                   <integer>368</integer>
                 </dict>
@@ -164,7 +164,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-727</string>
+                  <integer>-727</integer>
                   <key>y</key>
                   <integer>385</integer>
                 </dict>
@@ -174,7 +174,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-645</string>
+                  <integer>-645</integer>
                   <key>y</key>
                   <integer>385</integer>
                 </dict>
@@ -184,7 +184,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-633</string>
+                  <integer>-633</integer>
                   <key>y</key>
                   <integer>385</integer>
                 </dict>
@@ -192,7 +192,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-615</string>
+                  <integer>-615</integer>
                   <key>y</key>
                   <integer>385</integer>
                 </dict>
@@ -200,7 +200,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-591</string>
+                  <integer>-591</integer>
                   <key>y</key>
                   <integer>383</integer>
                 </dict>
@@ -210,7 +210,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-573</string>
+                  <integer>-573</integer>
                   <key>y</key>
                   <integer>379</integer>
                 </dict>
@@ -220,7 +220,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-573</string>
+                  <integer>-573</integer>
                   <key>y</key>
                   <integer>424</integer>
                 </dict>
@@ -228,7 +228,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-584</string>
+                  <integer>-584</integer>
                   <key>y</key>
                   <integer>426</integer>
                 </dict>
@@ -236,7 +236,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-615</string>
+                  <integer>-615</integer>
                   <key>y</key>
                   <integer>429</integer>
                 </dict>
@@ -246,7 +246,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-633</string>
+                  <integer>-633</integer>
                   <key>y</key>
                   <integer>429</integer>
                 </dict>
@@ -256,7 +256,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-645</string>
+                  <integer>-645</integer>
                   <key>y</key>
                   <integer>429</integer>
                 </dict>
@@ -264,7 +264,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-767</string>
+                  <integer>-767</integer>
                   <key>y</key>
                   <integer>429</integer>
                 </dict>
@@ -272,7 +272,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-829</string>
+                  <integer>-829</integer>
                   <key>y</key>
                   <integer>392</integer>
                 </dict>
@@ -282,7 +282,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-829</string>
+                  <integer>-829</integer>
                   <key>y</key>
                   <integer>282</integer>
                 </dict>
@@ -290,7 +290,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-829</string>
+                  <integer>-829</integer>
                   <key>y</key>
                   <integer>169</integer>
                 </dict>
@@ -298,7 +298,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-767</string>
+                  <integer>-767</integer>
                   <key>y</key>
                   <integer>136</integer>
                 </dict>
@@ -308,7 +308,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-645</string>
+                  <integer>-645</integer>
                   <key>y</key>
                   <integer>135</integer>
                 </dict>
@@ -318,7 +318,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-627</string>
+                  <integer>-627</integer>
                   <key>y</key>
                   <integer>135</integer>
                 </dict>
@@ -326,7 +326,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-589</string>
+                  <integer>-589</integer>
                   <key>y</key>
                   <integer>135</integer>
                 </dict>
@@ -334,7 +334,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-526</string>
+                  <integer>-526</integer>
                   <key>y</key>
                   <integer>140</integer>
                 </dict>
@@ -344,7 +344,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-478</string>
+                  <integer>-478</integer>
                   <key>y</key>
                   <integer>180</integer>
                 </dict>
@@ -354,7 +354,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-478</string>
+                  <integer>-478</integer>
                   <key>y</key>
                   <integer>229</integer>
                 </dict>
@@ -362,7 +362,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-526</string>
+                  <integer>-526</integer>
                   <key>y</key>
                   <integer>189</integer>
                 </dict>
@@ -370,7 +370,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-577</string>
+                  <integer>-577</integer>
                   <key>y</key>
                   <integer>179</integer>
                 </dict>
@@ -380,7 +380,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-627</string>
+                  <integer>-627</integer>
                   <key>y</key>
                   <integer>179</integer>
                 </dict>
@@ -390,7 +390,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-645</string>
+                  <integer>-645</integer>
                   <key>y</key>
                   <integer>179</integer>
                 </dict>
@@ -398,7 +398,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-728</string>
+                  <integer>-728</integer>
                   <key>y</key>
                   <integer>180</integer>
                 </dict>
@@ -406,7 +406,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-775</string>
+                  <integer>-775</integer>
                   <key>y</key>
                   <integer>192</integer>
                 </dict>
@@ -416,7 +416,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-775</string>
+                  <integer>-775</integer>
                   <key>y</key>
                   <integer>282</integer>
                 </dict>
@@ -429,7 +429,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-181</string>
+                  <integer>-181</integer>
                   <key>y</key>
                   <integer>196</integer>
                 </dict>
@@ -437,7 +437,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-229</string>
+                  <integer>-229</integer>
                   <key>y</key>
                   <integer>179</integer>
                 </dict>
@@ -447,7 +447,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-311</string>
+                  <integer>-311</integer>
                   <key>y</key>
                   <integer>179</integer>
                 </dict>
@@ -457,7 +457,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-323</string>
+                  <integer>-323</integer>
                   <key>y</key>
                   <integer>179</integer>
                 </dict>
@@ -465,7 +465,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-341</string>
+                  <integer>-341</integer>
                   <key>y</key>
                   <integer>179</integer>
                 </dict>
@@ -473,7 +473,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-365</string>
+                  <integer>-365</integer>
                   <key>y</key>
                   <integer>181</integer>
                 </dict>
@@ -483,7 +483,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-383</string>
+                  <integer>-383</integer>
                   <key>y</key>
                   <integer>185</integer>
                 </dict>
@@ -493,7 +493,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-383</string>
+                  <integer>-383</integer>
                   <key>y</key>
                   <integer>140</integer>
                 </dict>
@@ -501,7 +501,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-372</string>
+                  <integer>-372</integer>
                   <key>y</key>
                   <integer>138</integer>
                 </dict>
@@ -509,7 +509,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-341</string>
+                  <integer>-341</integer>
                   <key>y</key>
                   <integer>135</integer>
                 </dict>
@@ -519,7 +519,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-323</string>
+                  <integer>-323</integer>
                   <key>y</key>
                   <integer>135</integer>
                 </dict>
@@ -529,7 +529,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-311</string>
+                  <integer>-311</integer>
                   <key>y</key>
                   <integer>135</integer>
                 </dict>
@@ -537,7 +537,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-189</string>
+                  <integer>-189</integer>
                   <key>y</key>
                   <integer>135</integer>
                 </dict>
@@ -545,7 +545,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-127</string>
+                  <integer>-127</integer>
                   <key>y</key>
                   <integer>172</integer>
                 </dict>
@@ -555,7 +555,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-127</string>
+                  <integer>-127</integer>
                   <key>y</key>
                   <integer>282</integer>
                 </dict>
@@ -563,7 +563,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-127</string>
+                  <integer>-127</integer>
                   <key>y</key>
                   <integer>395</integer>
                 </dict>
@@ -571,7 +571,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-189</string>
+                  <integer>-189</integer>
                   <key>y</key>
                   <integer>428</integer>
                 </dict>
@@ -581,7 +581,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-311</string>
+                  <integer>-311</integer>
                   <key>y</key>
                   <integer>429</integer>
                 </dict>
@@ -591,7 +591,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-329</string>
+                  <integer>-329</integer>
                   <key>y</key>
                   <integer>429</integer>
                 </dict>
@@ -599,7 +599,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-367</string>
+                  <integer>-367</integer>
                   <key>y</key>
                   <integer>429</integer>
                 </dict>
@@ -607,7 +607,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-430</string>
+                  <integer>-430</integer>
                   <key>y</key>
                   <integer>424</integer>
                 </dict>
@@ -617,7 +617,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-478</string>
+                  <integer>-478</integer>
                   <key>y</key>
                   <integer>384</integer>
                 </dict>
@@ -627,7 +627,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-478</string>
+                  <integer>-478</integer>
                   <key>y</key>
                   <integer>335</integer>
                 </dict>
@@ -635,7 +635,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-430</string>
+                  <integer>-430</integer>
                   <key>y</key>
                   <integer>375</integer>
                 </dict>
@@ -643,7 +643,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-379</string>
+                  <integer>-379</integer>
                   <key>y</key>
                   <integer>385</integer>
                 </dict>
@@ -653,7 +653,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-329</string>
+                  <integer>-329</integer>
                   <key>y</key>
                   <integer>385</integer>
                 </dict>
@@ -663,7 +663,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-311</string>
+                  <integer>-311</integer>
                   <key>y</key>
                   <integer>385</integer>
                 </dict>
@@ -671,7 +671,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-228</string>
+                  <integer>-228</integer>
                   <key>y</key>
                   <integer>384</integer>
                 </dict>
@@ -679,7 +679,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-181</string>
+                  <integer>-181</integer>
                   <key>y</key>
                   <integer>372</integer>
                 </dict>
@@ -689,7 +689,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-181</string>
+                  <integer>-181</integer>
                   <key>y</key>
                   <integer>282</integer>
                 </dict>
@@ -704,7 +704,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-886</string>
+                  <integer>-886</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -714,7 +714,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-886</string>
+                  <integer>-886</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -724,7 +724,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-505</string>
+                  <integer>-505</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -734,7 +734,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-505</string>
+                  <integer>-505</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -744,7 +744,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-451</string>
+                  <integer>-451</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -754,17 +754,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-451</string>
-                  <key>y</key>
-                  <integer>590</integer>
-                </dict>
-                <dict>
-                  <key>segmentType</key>
-                  <string>line</string>
-                  <key>smooth</key>
-                  <integer>0</integer>
-                  <key>x</key>
-                  <string>-70</string>
+                  <integer>-451</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -774,7 +764,17 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-70</string>
+                  <integer>-70</integer>
+                  <key>y</key>
+                  <integer>590</integer>
+                </dict>
+                <dict>
+                  <key>segmentType</key>
+                  <string>line</string>
+                  <key>smooth</key>
+                  <integer>0</integer>
+                  <key>x</key>
+                  <integer>-70</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -1062,7 +1062,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>674</integer>
                 </dict>
@@ -1072,7 +1072,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>550</integer>
                 </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/kha-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/kha-deva.glif
@@ -99,7 +99,7 @@
               <key>x</key>
               <integer>268</integer>
               <key>y</key>
-              <string>-101</string>
+              <integer>-101</integer>
             </dict>
             <dict>
               <key>name</key>

--- a/Source Files/Biryani-Bold.ufo/glyphs/l.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/l.glif
@@ -70,7 +70,7 @@
                   <key>x</key>
                   <integer>255</integer>
                   <key>y</key>
-                  <string>-13</string>
+                  <integer>-13</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -78,7 +78,7 @@
                   <key>x</key>
                   <integer>270</integer>
                   <key>y</key>
-                  <string>-12</string>
+                  <integer>-12</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -88,7 +88,7 @@
                   <key>x</key>
                   <integer>285</integer>
                   <key>y</key>
-                  <string>-9</string>
+                  <integer>-9</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -196,7 +196,7 @@
                   <key>x</key>
                   <integer>156</integer>
                   <key>y</key>
-                  <string>-13</string>
+                  <integer>-13</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -206,7 +206,7 @@
                   <key>x</key>
                   <integer>244</integer>
                   <key>y</key>
-                  <string>-13</string>
+                  <integer>-13</integer>
                 </dict>
               </array>
             </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/lV_ocalic-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/lV_ocalic-deva.glif
@@ -99,7 +99,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-3086</string>
+                  <integer>-3086</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -109,7 +109,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-3086</string>
+                  <integer>-3086</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -119,7 +119,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2561</string>
+                  <integer>-2561</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -129,7 +129,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2561</string>
+                  <integer>-2561</integer>
                   <key>y</key>
                   <integer>400</integer>
                 </dict>
@@ -139,7 +139,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2507</string>
+                  <integer>-2507</integer>
                   <key>y</key>
                   <integer>400</integer>
                 </dict>
@@ -149,7 +149,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2507</string>
+                  <integer>-2507</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -159,7 +159,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2297</string>
+                  <integer>-2297</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -169,7 +169,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2297</string>
+                  <integer>-2297</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -182,7 +182,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2658</string>
+                  <integer>-2658</integer>
                   <key>y</key>
                   <integer>350</integer>
                 </dict>
@@ -190,7 +190,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2717</string>
+                  <integer>-2717</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -200,7 +200,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2836</string>
+                  <integer>-2836</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -208,7 +208,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2955</string>
+                  <integer>-2955</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -216,7 +216,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-3014</string>
+                  <integer>-3014</integer>
                   <key>y</key>
                   <integer>350</integer>
                 </dict>
@@ -226,7 +226,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-3014</string>
+                  <integer>-3014</integer>
                   <key>y</key>
                   <integer>237</integer>
                 </dict>
@@ -234,7 +234,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-3014</string>
+                  <integer>-3014</integer>
                   <key>y</key>
                   <integer>122</integer>
                 </dict>
@@ -242,7 +242,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2956</string>
+                  <integer>-2956</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -252,7 +252,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-2756</string>
+                  <integer>-2756</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -262,7 +262,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2744</string>
+                  <integer>-2744</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -272,7 +272,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2744</string>
+                  <integer>-2744</integer>
                   <key>y</key>
                   <integer>44</integer>
                 </dict>
@@ -282,7 +282,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-2756</string>
+                  <integer>-2756</integer>
                   <key>y</key>
                   <integer>44</integer>
                 </dict>
@@ -290,7 +290,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2924</string>
+                  <integer>-2924</integer>
                   <key>y</key>
                   <integer>44</integer>
                 </dict>
@@ -298,7 +298,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2957</string>
+                  <integer>-2957</integer>
                   <key>y</key>
                   <integer>142</integer>
                 </dict>
@@ -308,7 +308,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2960</string>
+                  <integer>-2960</integer>
                   <key>y</key>
                   <integer>237</integer>
                 </dict>
@@ -316,7 +316,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2958</string>
+                  <integer>-2958</integer>
                   <key>y</key>
                   <integer>329</integer>
                 </dict>
@@ -324,7 +324,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2918</string>
+                  <integer>-2918</integer>
                   <key>y</key>
                   <integer>386</integer>
                 </dict>
@@ -334,7 +334,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2836</string>
+                  <integer>-2836</integer>
                   <key>y</key>
                   <integer>386</integer>
                 </dict>
@@ -342,7 +342,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2754</string>
+                  <integer>-2754</integer>
                   <key>y</key>
                   <integer>386</integer>
                 </dict>
@@ -350,7 +350,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2714</string>
+                  <integer>-2714</integer>
                   <key>y</key>
                   <integer>329</integer>
                 </dict>
@@ -360,7 +360,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2712</string>
+                  <integer>-2712</integer>
                   <key>y</key>
                   <integer>237</integer>
                 </dict>
@@ -370,7 +370,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2712</string>
+                  <integer>-2712</integer>
                   <key>y</key>
                   <integer>198</integer>
                 </dict>
@@ -380,7 +380,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2658</string>
+                  <integer>-2658</integer>
                   <key>y</key>
                   <integer>198</integer>
                 </dict>
@@ -390,7 +390,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2658</string>
+                  <integer>-2658</integer>
                   <key>y</key>
                   <integer>237</integer>
                 </dict>
@@ -405,7 +405,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2712</string>
+                  <integer>-2712</integer>
                   <key>y</key>
                   <integer>198</integer>
                 </dict>
@@ -415,7 +415,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2658</string>
+                  <integer>-2658</integer>
                   <key>y</key>
                   <integer>198</integer>
                 </dict>
@@ -425,7 +425,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2658</string>
+                  <integer>-2658</integer>
                   <key>y</key>
                   <integer>237</integer>
                 </dict>
@@ -433,7 +433,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2656</string>
+                  <integer>-2656</integer>
                   <key>y</key>
                   <integer>329</integer>
                 </dict>
@@ -441,7 +441,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2616</string>
+                  <integer>-2616</integer>
                   <key>y</key>
                   <integer>386</integer>
                 </dict>
@@ -451,7 +451,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-2534</string>
+                  <integer>-2534</integer>
                   <key>y</key>
                   <integer>386</integer>
                 </dict>
@@ -459,7 +459,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2468</string>
+                  <integer>-2468</integer>
                   <key>y</key>
                   <integer>386</integer>
                 </dict>
@@ -467,7 +467,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2430</string>
+                  <integer>-2430</integer>
                   <key>y</key>
                   <integer>356</integer>
                 </dict>
@@ -477,7 +477,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-2430</string>
+                  <integer>-2430</integer>
                   <key>y</key>
                   <integer>295</integer>
                 </dict>
@@ -485,7 +485,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2430</string>
+                  <integer>-2430</integer>
                   <key>y</key>
                   <integer>168</integer>
                 </dict>
@@ -493,7 +493,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2588</string>
+                  <integer>-2588</integer>
                   <key>y</key>
                   <integer>115</integer>
                 </dict>
@@ -503,7 +503,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-2591</string>
+                  <integer>-2591</integer>
                   <key>y</key>
                   <integer>12</integer>
                 </dict>
@@ -511,17 +511,17 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2593</string>
+                  <integer>-2593</integer>
                   <key>y</key>
-                  <string>-43</string>
+                  <integer>-43</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2544</string>
+                  <integer>-2544</integer>
                   <key>y</key>
-                  <string>-97</string>
+                  <integer>-97</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -529,25 +529,25 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-2446</string>
+                  <integer>-2446</integer>
                   <key>y</key>
-                  <string>-97</string>
+                  <integer>-97</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2395</string>
+                  <integer>-2395</integer>
                   <key>y</key>
-                  <string>-97</string>
+                  <integer>-97</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2360</string>
+                  <integer>-2360</integer>
                   <key>y</key>
-                  <string>-83</string>
+                  <integer>-83</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -555,9 +555,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2329</string>
+                  <integer>-2329</integer>
                   <key>y</key>
-                  <string>-61</string>
+                  <integer>-61</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -565,25 +565,25 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2329</string>
+                  <integer>-2329</integer>
                   <key>y</key>
-                  <string>-11</string>
+                  <integer>-11</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2357</string>
+                  <integer>-2357</integer>
                   <key>y</key>
-                  <string>-31</string>
+                  <integer>-31</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2404</string>
+                  <integer>-2404</integer>
                   <key>y</key>
-                  <string>-53</string>
+                  <integer>-53</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -591,25 +591,25 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-2446</string>
+                  <integer>-2446</integer>
                   <key>y</key>
-                  <string>-53</string>
+                  <integer>-53</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2515</string>
+                  <integer>-2515</integer>
                   <key>y</key>
-                  <string>-53</string>
+                  <integer>-53</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2538</string>
+                  <integer>-2538</integer>
                   <key>y</key>
-                  <string>-24</string>
+                  <integer>-24</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -617,7 +617,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-2537</string>
+                  <integer>-2537</integer>
                   <key>y</key>
                   <integer>12</integer>
                 </dict>
@@ -625,7 +625,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2534</string>
+                  <integer>-2534</integer>
                   <key>y</key>
                   <integer>90</integer>
                 </dict>
@@ -633,7 +633,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2376</string>
+                  <integer>-2376</integer>
                   <key>y</key>
                   <integer>157</integer>
                 </dict>
@@ -643,7 +643,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-2376</string>
+                  <integer>-2376</integer>
                   <key>y</key>
                   <integer>295</integer>
                 </dict>
@@ -651,7 +651,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2376</string>
+                  <integer>-2376</integer>
                   <key>y</key>
                   <integer>368</integer>
                 </dict>
@@ -659,7 +659,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2430</string>
+                  <integer>-2430</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -669,7 +669,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-2534</string>
+                  <integer>-2534</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -677,7 +677,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2653</string>
+                  <integer>-2653</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -685,7 +685,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2712</string>
+                  <integer>-2712</integer>
                   <key>y</key>
                   <integer>350</integer>
                 </dict>
@@ -695,7 +695,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2712</string>
+                  <integer>-2712</integer>
                   <key>y</key>
                   <integer>237</integer>
                 </dict>
@@ -710,7 +710,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2317</string>
+                  <integer>-2317</integer>
                   <key>y</key>
                   <integer>674</integer>
                 </dict>
@@ -720,7 +720,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2317</string>
+                  <integer>-2317</integer>
                   <key>y</key>
                   <integer>550</integer>
                 </dict>
@@ -730,7 +730,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1842</string>
+                  <integer>-1842</integer>
                   <key>y</key>
                   <integer>550</integer>
                 </dict>
@@ -740,7 +740,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1842</string>
+                  <integer>-1842</integer>
                   <key>y</key>
                   <integer>400</integer>
                 </dict>
@@ -750,7 +750,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1688</string>
+                  <integer>-1688</integer>
                   <key>y</key>
                   <integer>400</integer>
                 </dict>
@@ -760,7 +760,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1688</string>
+                  <integer>-1688</integer>
                   <key>y</key>
                   <integer>550</integer>
                 </dict>
@@ -770,7 +770,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1528</string>
+                  <integer>-1528</integer>
                   <key>y</key>
                   <integer>550</integer>
                 </dict>
@@ -780,7 +780,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1528</string>
+                  <integer>-1528</integer>
                   <key>y</key>
                   <integer>674</integer>
                 </dict>
@@ -795,7 +795,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1943</string>
+                  <integer>-1943</integer>
                   <key>y</key>
                   <integer>198</integer>
                 </dict>
@@ -805,7 +805,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1889</string>
+                  <integer>-1889</integer>
                   <key>y</key>
                   <integer>198</integer>
                 </dict>
@@ -815,7 +815,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1889</string>
+                  <integer>-1889</integer>
                   <key>y</key>
                   <integer>237</integer>
                 </dict>
@@ -823,7 +823,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1887</string>
+                  <integer>-1887</integer>
                   <key>y</key>
                   <integer>329</integer>
                 </dict>
@@ -831,7 +831,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1847</string>
+                  <integer>-1847</integer>
                   <key>y</key>
                   <integer>386</integer>
                 </dict>
@@ -841,7 +841,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1765</string>
+                  <integer>-1765</integer>
                   <key>y</key>
                   <integer>386</integer>
                 </dict>
@@ -849,7 +849,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1699</string>
+                  <integer>-1699</integer>
                   <key>y</key>
                   <integer>386</integer>
                 </dict>
@@ -857,7 +857,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1661</string>
+                  <integer>-1661</integer>
                   <key>y</key>
                   <integer>356</integer>
                 </dict>
@@ -867,7 +867,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1661</string>
+                  <integer>-1661</integer>
                   <key>y</key>
                   <integer>295</integer>
                 </dict>
@@ -875,7 +875,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1661</string>
+                  <integer>-1661</integer>
                   <key>y</key>
                   <integer>168</integer>
                 </dict>
@@ -883,7 +883,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1819</string>
+                  <integer>-1819</integer>
                   <key>y</key>
                   <integer>115</integer>
                 </dict>
@@ -893,7 +893,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1822</string>
+                  <integer>-1822</integer>
                   <key>y</key>
                   <integer>12</integer>
                 </dict>
@@ -901,17 +901,17 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1824</string>
+                  <integer>-1824</integer>
                   <key>y</key>
-                  <string>-43</string>
+                  <integer>-43</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1775</string>
+                  <integer>-1775</integer>
                   <key>y</key>
-                  <string>-97</string>
+                  <integer>-97</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -919,25 +919,25 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1677</string>
+                  <integer>-1677</integer>
                   <key>y</key>
-                  <string>-97</string>
+                  <integer>-97</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1626</string>
+                  <integer>-1626</integer>
                   <key>y</key>
-                  <string>-97</string>
+                  <integer>-97</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1591</string>
+                  <integer>-1591</integer>
                   <key>y</key>
-                  <string>-83</string>
+                  <integer>-83</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -945,9 +945,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1560</string>
+                  <integer>-1560</integer>
                   <key>y</key>
-                  <string>-61</string>
+                  <integer>-61</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -955,25 +955,25 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1560</string>
+                  <integer>-1560</integer>
                   <key>y</key>
-                  <string>-11</string>
+                  <integer>-11</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1588</string>
+                  <integer>-1588</integer>
                   <key>y</key>
-                  <string>-31</string>
+                  <integer>-31</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1635</string>
+                  <integer>-1635</integer>
                   <key>y</key>
-                  <string>-53</string>
+                  <integer>-53</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -981,25 +981,25 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1677</string>
+                  <integer>-1677</integer>
                   <key>y</key>
-                  <string>-53</string>
+                  <integer>-53</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1746</string>
+                  <integer>-1746</integer>
                   <key>y</key>
-                  <string>-53</string>
+                  <integer>-53</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1769</string>
+                  <integer>-1769</integer>
                   <key>y</key>
-                  <string>-24</string>
+                  <integer>-24</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -1007,7 +1007,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1768</string>
+                  <integer>-1768</integer>
                   <key>y</key>
                   <integer>12</integer>
                 </dict>
@@ -1015,7 +1015,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1765</string>
+                  <integer>-1765</integer>
                   <key>y</key>
                   <integer>90</integer>
                 </dict>
@@ -1023,7 +1023,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1607</string>
+                  <integer>-1607</integer>
                   <key>y</key>
                   <integer>157</integer>
                 </dict>
@@ -1033,7 +1033,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1607</string>
+                  <integer>-1607</integer>
                   <key>y</key>
                   <integer>295</integer>
                 </dict>
@@ -1041,7 +1041,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1607</string>
+                  <integer>-1607</integer>
                   <key>y</key>
                   <integer>368</integer>
                 </dict>
@@ -1049,7 +1049,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1661</string>
+                  <integer>-1661</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -1059,7 +1059,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1765</string>
+                  <integer>-1765</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -1067,7 +1067,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1884</string>
+                  <integer>-1884</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -1075,7 +1075,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1943</string>
+                  <integer>-1943</integer>
                   <key>y</key>
                   <integer>350</integer>
                 </dict>
@@ -1085,7 +1085,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1943</string>
+                  <integer>-1943</integer>
                   <key>y</key>
                   <integer>237</integer>
                 </dict>
@@ -1098,7 +1098,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1879</string>
+                  <integer>-1879</integer>
                   <key>y</key>
                   <integer>350</integer>
                 </dict>
@@ -1106,7 +1106,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1927</string>
+                  <integer>-1927</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -1116,7 +1116,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2054</string>
+                  <integer>-2054</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -1124,7 +1124,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2182</string>
+                  <integer>-2182</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -1132,7 +1132,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2245</string>
+                  <integer>-2245</integer>
                   <key>y</key>
                   <integer>342</integer>
                 </dict>
@@ -1142,7 +1142,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-2245</string>
+                  <integer>-2245</integer>
                   <key>y</key>
                   <integer>217</integer>
                 </dict>
@@ -1150,7 +1150,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2245</string>
+                  <integer>-2245</integer>
                   <key>y</key>
                   <integer>112</integer>
                 </dict>
@@ -1158,7 +1158,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2194</string>
+                  <integer>-2194</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -1168,7 +1168,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-2017</string>
+                  <integer>-2017</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -1178,7 +1178,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1965</string>
+                  <integer>-1965</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -1188,7 +1188,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1965</string>
+                  <integer>-1965</integer>
                   <key>y</key>
                   <integer>124</integer>
                 </dict>
@@ -1198,7 +1198,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-2017</string>
+                  <integer>-2017</integer>
                   <key>y</key>
                   <integer>124</integer>
                 </dict>
@@ -1206,7 +1206,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2078</string>
+                  <integer>-2078</integer>
                   <key>y</key>
                   <integer>124</integer>
                 </dict>
@@ -1214,7 +1214,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2091</string>
+                  <integer>-2091</integer>
                   <key>y</key>
                   <integer>171</integer>
                 </dict>
@@ -1224,7 +1224,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-2091</string>
+                  <integer>-2091</integer>
                   <key>y</key>
                   <integer>217</integer>
                 </dict>
@@ -1232,7 +1232,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2091</string>
+                  <integer>-2091</integer>
                   <key>y</key>
                   <integer>280</integer>
                 </dict>
@@ -1240,7 +1240,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2073</string>
+                  <integer>-2073</integer>
                   <key>y</key>
                   <integer>306</integer>
                 </dict>
@@ -1250,7 +1250,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2034</string>
+                  <integer>-2034</integer>
                   <key>y</key>
                   <integer>306</integer>
                 </dict>
@@ -1258,7 +1258,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2001</string>
+                  <integer>-2001</integer>
                   <key>y</key>
                   <integer>306</integer>
                 </dict>
@@ -1266,7 +1266,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1983</string>
+                  <integer>-1983</integer>
                   <key>y</key>
                   <integer>280</integer>
                 </dict>
@@ -1276,7 +1276,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1983</string>
+                  <integer>-1983</integer>
                   <key>y</key>
                   <integer>217</integer>
                 </dict>
@@ -1286,7 +1286,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1983</string>
+                  <integer>-1983</integer>
                   <key>y</key>
                   <integer>198</integer>
                 </dict>
@@ -1296,7 +1296,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1879</string>
+                  <integer>-1879</integer>
                   <key>y</key>
                   <integer>198</integer>
                 </dict>
@@ -1306,7 +1306,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1879</string>
+                  <integer>-1879</integer>
                   <key>y</key>
                   <integer>237</integer>
                 </dict>
@@ -1319,7 +1319,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1935</string>
+                  <integer>-1935</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -1327,7 +1327,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1983</string>
+                  <integer>-1983</integer>
                   <key>y</key>
                   <integer>350</integer>
                 </dict>
@@ -1337,7 +1337,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1983</string>
+                  <integer>-1983</integer>
                   <key>y</key>
                   <integer>237</integer>
                 </dict>
@@ -1347,7 +1347,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1983</string>
+                  <integer>-1983</integer>
                   <key>y</key>
                   <integer>198</integer>
                 </dict>
@@ -1357,7 +1357,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1879</string>
+                  <integer>-1879</integer>
                   <key>y</key>
                   <integer>198</integer>
                 </dict>
@@ -1367,7 +1367,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1879</string>
+                  <integer>-1879</integer>
                   <key>y</key>
                   <integer>217</integer>
                 </dict>
@@ -1375,7 +1375,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1879</string>
+                  <integer>-1879</integer>
                   <key>y</key>
                   <integer>280</integer>
                 </dict>
@@ -1383,7 +1383,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1861</string>
+                  <integer>-1861</integer>
                   <key>y</key>
                   <integer>306</integer>
                 </dict>
@@ -1393,7 +1393,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1828</string>
+                  <integer>-1828</integer>
                   <key>y</key>
                   <integer>306</integer>
                 </dict>
@@ -1401,7 +1401,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1789</string>
+                  <integer>-1789</integer>
                   <key>y</key>
                   <integer>306</integer>
                 </dict>
@@ -1409,7 +1409,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1771</string>
+                  <integer>-1771</integer>
                   <key>y</key>
                   <integer>280</integer>
                 </dict>
@@ -1419,7 +1419,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1771</string>
+                  <integer>-1771</integer>
                   <key>y</key>
                   <integer>217</integer>
                 </dict>
@@ -1427,7 +1427,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1771</string>
+                  <integer>-1771</integer>
                   <key>y</key>
                   <integer>171</integer>
                 </dict>
@@ -1435,7 +1435,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1784</string>
+                  <integer>-1784</integer>
                   <key>y</key>
                   <integer>124</integer>
                 </dict>
@@ -1445,7 +1445,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1845</string>
+                  <integer>-1845</integer>
                   <key>y</key>
                   <integer>124</integer>
                 </dict>
@@ -1455,7 +1455,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1897</string>
+                  <integer>-1897</integer>
                   <key>y</key>
                   <integer>124</integer>
                 </dict>
@@ -1465,7 +1465,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1897</string>
+                  <integer>-1897</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -1475,7 +1475,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1845</string>
+                  <integer>-1845</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -1483,7 +1483,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1668</string>
+                  <integer>-1668</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -1491,7 +1491,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1617</string>
+                  <integer>-1617</integer>
                   <key>y</key>
                   <integer>112</integer>
                 </dict>
@@ -1501,7 +1501,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1617</string>
+                  <integer>-1617</integer>
                   <key>y</key>
                   <integer>217</integer>
                 </dict>
@@ -1509,7 +1509,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1617</string>
+                  <integer>-1617</integer>
                   <key>y</key>
                   <integer>342</integer>
                 </dict>
@@ -1517,7 +1517,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1680</string>
+                  <integer>-1680</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -1527,7 +1527,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1808</string>
+                  <integer>-1808</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -1542,7 +1542,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1548</string>
+                  <integer>-1548</integer>
                   <key>y</key>
                   <integer>674</integer>
                 </dict>
@@ -1552,7 +1552,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1548</string>
+                  <integer>-1548</integer>
                   <key>y</key>
                   <integer>550</integer>
                 </dict>
@@ -1562,7 +1562,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1073</string>
+                  <integer>-1073</integer>
                   <key>y</key>
                   <integer>550</integer>
                 </dict>
@@ -1572,7 +1572,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1073</string>
+                  <integer>-1073</integer>
                   <key>y</key>
                   <integer>400</integer>
                 </dict>
@@ -1582,7 +1582,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-919</string>
+                  <integer>-919</integer>
                   <key>y</key>
                   <integer>400</integer>
                 </dict>
@@ -1592,7 +1592,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-919</string>
+                  <integer>-919</integer>
                   <key>y</key>
                   <integer>550</integer>
                 </dict>
@@ -1602,7 +1602,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-759</string>
+                  <integer>-759</integer>
                   <key>y</key>
                   <integer>550</integer>
                 </dict>
@@ -1612,7 +1612,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-759</string>
+                  <integer>-759</integer>
                   <key>y</key>
                   <integer>674</integer>
                 </dict>
@@ -1625,7 +1625,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1110</string>
+                  <integer>-1110</integer>
                   <key>y</key>
                   <integer>350</integer>
                 </dict>
@@ -1633,7 +1633,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1158</string>
+                  <integer>-1158</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -1643,7 +1643,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1285</string>
+                  <integer>-1285</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -1651,7 +1651,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1413</string>
+                  <integer>-1413</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -1659,7 +1659,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1476</string>
+                  <integer>-1476</integer>
                   <key>y</key>
                   <integer>342</integer>
                 </dict>
@@ -1669,7 +1669,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1476</string>
+                  <integer>-1476</integer>
                   <key>y</key>
                   <integer>217</integer>
                 </dict>
@@ -1677,7 +1677,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1476</string>
+                  <integer>-1476</integer>
                   <key>y</key>
                   <integer>112</integer>
                 </dict>
@@ -1685,7 +1685,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1425</string>
+                  <integer>-1425</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -1695,7 +1695,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1248</string>
+                  <integer>-1248</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -1705,7 +1705,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1196</string>
+                  <integer>-1196</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -1715,7 +1715,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1196</string>
+                  <integer>-1196</integer>
                   <key>y</key>
                   <integer>124</integer>
                 </dict>
@@ -1725,7 +1725,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1248</string>
+                  <integer>-1248</integer>
                   <key>y</key>
                   <integer>124</integer>
                 </dict>
@@ -1733,7 +1733,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1309</string>
+                  <integer>-1309</integer>
                   <key>y</key>
                   <integer>124</integer>
                 </dict>
@@ -1741,7 +1741,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1322</string>
+                  <integer>-1322</integer>
                   <key>y</key>
                   <integer>171</integer>
                 </dict>
@@ -1751,7 +1751,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1322</string>
+                  <integer>-1322</integer>
                   <key>y</key>
                   <integer>217</integer>
                 </dict>
@@ -1759,7 +1759,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1322</string>
+                  <integer>-1322</integer>
                   <key>y</key>
                   <integer>280</integer>
                 </dict>
@@ -1767,7 +1767,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1304</string>
+                  <integer>-1304</integer>
                   <key>y</key>
                   <integer>306</integer>
                 </dict>
@@ -1777,7 +1777,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1265</string>
+                  <integer>-1265</integer>
                   <key>y</key>
                   <integer>306</integer>
                 </dict>
@@ -1785,7 +1785,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1232</string>
+                  <integer>-1232</integer>
                   <key>y</key>
                   <integer>306</integer>
                 </dict>
@@ -1793,7 +1793,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1214</string>
+                  <integer>-1214</integer>
                   <key>y</key>
                   <integer>280</integer>
                 </dict>
@@ -1803,7 +1803,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1214</string>
+                  <integer>-1214</integer>
                   <key>y</key>
                   <integer>217</integer>
                 </dict>
@@ -1813,7 +1813,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1214</string>
+                  <integer>-1214</integer>
                   <key>y</key>
                   <integer>198</integer>
                 </dict>
@@ -1823,7 +1823,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1110</string>
+                  <integer>-1110</integer>
                   <key>y</key>
                   <integer>198</integer>
                 </dict>
@@ -1833,7 +1833,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1110</string>
+                  <integer>-1110</integer>
                   <key>y</key>
                   <integer>237</integer>
                 </dict>
@@ -1848,7 +1848,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1174</string>
+                  <integer>-1174</integer>
                   <key>y</key>
                   <integer>198</integer>
                 </dict>
@@ -1858,7 +1858,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1120</string>
+                  <integer>-1120</integer>
                   <key>y</key>
                   <integer>198</integer>
                 </dict>
@@ -1868,7 +1868,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1120</string>
+                  <integer>-1120</integer>
                   <key>y</key>
                   <integer>237</integer>
                 </dict>
@@ -1876,7 +1876,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1118</string>
+                  <integer>-1118</integer>
                   <key>y</key>
                   <integer>329</integer>
                 </dict>
@@ -1884,7 +1884,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1078</string>
+                  <integer>-1078</integer>
                   <key>y</key>
                   <integer>386</integer>
                 </dict>
@@ -1894,7 +1894,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-996</string>
+                  <integer>-996</integer>
                   <key>y</key>
                   <integer>386</integer>
                 </dict>
@@ -1902,7 +1902,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-930</string>
+                  <integer>-930</integer>
                   <key>y</key>
                   <integer>386</integer>
                 </dict>
@@ -1910,7 +1910,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-892</string>
+                  <integer>-892</integer>
                   <key>y</key>
                   <integer>356</integer>
                 </dict>
@@ -1920,7 +1920,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-892</string>
+                  <integer>-892</integer>
                   <key>y</key>
                   <integer>295</integer>
                 </dict>
@@ -1928,7 +1928,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-892</string>
+                  <integer>-892</integer>
                   <key>y</key>
                   <integer>168</integer>
                 </dict>
@@ -1936,7 +1936,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1050</string>
+                  <integer>-1050</integer>
                   <key>y</key>
                   <integer>115</integer>
                 </dict>
@@ -1946,7 +1946,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1053</string>
+                  <integer>-1053</integer>
                   <key>y</key>
                   <integer>12</integer>
                 </dict>
@@ -1954,17 +1954,17 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1055</string>
+                  <integer>-1055</integer>
                   <key>y</key>
-                  <string>-43</string>
+                  <integer>-43</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1006</string>
+                  <integer>-1006</integer>
                   <key>y</key>
-                  <string>-97</string>
+                  <integer>-97</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -1972,25 +1972,25 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-908</string>
+                  <integer>-908</integer>
                   <key>y</key>
-                  <string>-97</string>
+                  <integer>-97</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-857</string>
+                  <integer>-857</integer>
                   <key>y</key>
-                  <string>-97</string>
+                  <integer>-97</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-822</string>
+                  <integer>-822</integer>
                   <key>y</key>
-                  <string>-83</string>
+                  <integer>-83</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -1998,9 +1998,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-791</string>
+                  <integer>-791</integer>
                   <key>y</key>
-                  <string>-61</string>
+                  <integer>-61</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -2008,25 +2008,25 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-791</string>
+                  <integer>-791</integer>
                   <key>y</key>
-                  <string>-11</string>
+                  <integer>-11</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-819</string>
+                  <integer>-819</integer>
                   <key>y</key>
-                  <string>-31</string>
+                  <integer>-31</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-866</string>
+                  <integer>-866</integer>
                   <key>y</key>
-                  <string>-53</string>
+                  <integer>-53</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -2034,25 +2034,25 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-908</string>
+                  <integer>-908</integer>
                   <key>y</key>
-                  <string>-53</string>
+                  <integer>-53</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-977</string>
+                  <integer>-977</integer>
                   <key>y</key>
-                  <string>-53</string>
+                  <integer>-53</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1000</string>
+                  <integer>-1000</integer>
                   <key>y</key>
-                  <string>-24</string>
+                  <integer>-24</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -2060,7 +2060,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-999</string>
+                  <integer>-999</integer>
                   <key>y</key>
                   <integer>12</integer>
                 </dict>
@@ -2068,7 +2068,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-996</string>
+                  <integer>-996</integer>
                   <key>y</key>
                   <integer>90</integer>
                 </dict>
@@ -2076,7 +2076,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-838</string>
+                  <integer>-838</integer>
                   <key>y</key>
                   <integer>157</integer>
                 </dict>
@@ -2086,7 +2086,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-838</string>
+                  <integer>-838</integer>
                   <key>y</key>
                   <integer>295</integer>
                 </dict>
@@ -2094,7 +2094,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-838</string>
+                  <integer>-838</integer>
                   <key>y</key>
                   <integer>368</integer>
                 </dict>
@@ -2102,7 +2102,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-892</string>
+                  <integer>-892</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -2112,7 +2112,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-996</string>
+                  <integer>-996</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -2120,7 +2120,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1115</string>
+                  <integer>-1115</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -2128,7 +2128,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1174</string>
+                  <integer>-1174</integer>
                   <key>y</key>
                   <integer>350</integer>
                 </dict>
@@ -2138,7 +2138,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1174</string>
+                  <integer>-1174</integer>
                   <key>y</key>
                   <integer>237</integer>
                 </dict>
@@ -2151,7 +2151,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1110</string>
+                  <integer>-1110</integer>
                   <key>y</key>
                   <integer>350</integer>
                 </dict>
@@ -2159,7 +2159,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1158</string>
+                  <integer>-1158</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -2169,7 +2169,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1285</string>
+                  <integer>-1285</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -2177,7 +2177,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1413</string>
+                  <integer>-1413</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -2185,7 +2185,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1476</string>
+                  <integer>-1476</integer>
                   <key>y</key>
                   <integer>342</integer>
                 </dict>
@@ -2195,7 +2195,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1476</string>
+                  <integer>-1476</integer>
                   <key>y</key>
                   <integer>217</integer>
                 </dict>
@@ -2203,7 +2203,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1476</string>
+                  <integer>-1476</integer>
                   <key>y</key>
                   <integer>112</integer>
                 </dict>
@@ -2211,7 +2211,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1425</string>
+                  <integer>-1425</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -2221,7 +2221,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1248</string>
+                  <integer>-1248</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -2231,7 +2231,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1196</string>
+                  <integer>-1196</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -2241,7 +2241,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1196</string>
+                  <integer>-1196</integer>
                   <key>y</key>
                   <integer>124</integer>
                 </dict>
@@ -2251,7 +2251,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1248</string>
+                  <integer>-1248</integer>
                   <key>y</key>
                   <integer>124</integer>
                 </dict>
@@ -2259,7 +2259,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1309</string>
+                  <integer>-1309</integer>
                   <key>y</key>
                   <integer>124</integer>
                 </dict>
@@ -2267,7 +2267,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1322</string>
+                  <integer>-1322</integer>
                   <key>y</key>
                   <integer>171</integer>
                 </dict>
@@ -2277,7 +2277,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1322</string>
+                  <integer>-1322</integer>
                   <key>y</key>
                   <integer>217</integer>
                 </dict>
@@ -2285,7 +2285,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1322</string>
+                  <integer>-1322</integer>
                   <key>y</key>
                   <integer>280</integer>
                 </dict>
@@ -2293,7 +2293,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1304</string>
+                  <integer>-1304</integer>
                   <key>y</key>
                   <integer>306</integer>
                 </dict>
@@ -2303,7 +2303,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1265</string>
+                  <integer>-1265</integer>
                   <key>y</key>
                   <integer>306</integer>
                 </dict>
@@ -2311,7 +2311,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1232</string>
+                  <integer>-1232</integer>
                   <key>y</key>
                   <integer>306</integer>
                 </dict>
@@ -2319,7 +2319,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1214</string>
+                  <integer>-1214</integer>
                   <key>y</key>
                   <integer>280</integer>
                 </dict>
@@ -2329,7 +2329,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1214</string>
+                  <integer>-1214</integer>
                   <key>y</key>
                   <integer>217</integer>
                 </dict>
@@ -2339,7 +2339,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1214</string>
+                  <integer>-1214</integer>
                   <key>y</key>
                   <integer>198</integer>
                 </dict>
@@ -2349,7 +2349,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1110</string>
+                  <integer>-1110</integer>
                   <key>y</key>
                   <integer>198</integer>
                 </dict>
@@ -2359,7 +2359,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1110</string>
+                  <integer>-1110</integer>
                   <key>y</key>
                   <integer>237</integer>
                 </dict>
@@ -2374,7 +2374,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1164</string>
+                  <integer>-1164</integer>
                   <key>y</key>
                   <integer>198</integer>
                 </dict>
@@ -2384,7 +2384,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1060</string>
+                  <integer>-1060</integer>
                   <key>y</key>
                   <integer>198</integer>
                 </dict>
@@ -2394,7 +2394,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1060</string>
+                  <integer>-1060</integer>
                   <key>y</key>
                   <integer>217</integer>
                 </dict>
@@ -2402,7 +2402,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1060</string>
+                  <integer>-1060</integer>
                   <key>y</key>
                   <integer>285</integer>
                 </dict>
@@ -2410,7 +2410,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1039</string>
+                  <integer>-1039</integer>
                   <key>y</key>
                   <integer>316</integer>
                 </dict>
@@ -2420,7 +2420,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-996</string>
+                  <integer>-996</integer>
                   <key>y</key>
                   <integer>316</integer>
                 </dict>
@@ -2428,7 +2428,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-967</string>
+                  <integer>-967</integer>
                   <key>y</key>
                   <integer>316</integer>
                 </dict>
@@ -2436,7 +2436,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-946</string>
+                  <integer>-946</integer>
                   <key>y</key>
                   <integer>302</integer>
                 </dict>
@@ -2446,7 +2446,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-927</string>
+                  <integer>-927</integer>
                   <key>y</key>
                   <integer>280</integer>
                 </dict>
@@ -2456,7 +2456,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-927</string>
+                  <integer>-927</integer>
                   <key>y</key>
                   <integer>421</integer>
                 </dict>
@@ -2464,7 +2464,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-950</string>
+                  <integer>-950</integer>
                   <key>y</key>
                   <integer>432</integer>
                 </dict>
@@ -2472,7 +2472,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-974</string>
+                  <integer>-974</integer>
                   <key>y</key>
                   <integer>440</integer>
                 </dict>
@@ -2482,7 +2482,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1006</string>
+                  <integer>-1006</integer>
                   <key>y</key>
                   <integer>440</integer>
                 </dict>
@@ -2490,7 +2490,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1123</string>
+                  <integer>-1123</integer>
                   <key>y</key>
                   <integer>440</integer>
                 </dict>
@@ -2498,7 +2498,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1164</string>
+                  <integer>-1164</integer>
                   <key>y</key>
                   <integer>360</integer>
                 </dict>
@@ -2508,7 +2508,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1164</string>
+                  <integer>-1164</integer>
                   <key>y</key>
                   <integer>247</integer>
                 </dict>
@@ -2523,7 +2523,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-779</string>
+                  <integer>-779</integer>
                   <key>y</key>
                   <integer>674</integer>
                 </dict>
@@ -2533,7 +2533,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-779</string>
+                  <integer>-779</integer>
                   <key>y</key>
                   <integer>550</integer>
                 </dict>
@@ -2543,7 +2543,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-304</string>
+                  <integer>-304</integer>
                   <key>y</key>
                   <integer>550</integer>
                 </dict>
@@ -2553,7 +2553,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-304</string>
+                  <integer>-304</integer>
                   <key>y</key>
                   <integer>400</integer>
                 </dict>
@@ -2563,7 +2563,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-150</string>
+                  <integer>-150</integer>
                   <key>y</key>
                   <integer>400</integer>
                 </dict>
@@ -2573,7 +2573,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-150</string>
+                  <integer>-150</integer>
                   <key>y</key>
                   <integer>550</integer>
                 </dict>
@@ -2606,7 +2606,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-341</string>
+                  <integer>-341</integer>
                   <key>y</key>
                   <integer>350</integer>
                 </dict>
@@ -2614,7 +2614,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-389</string>
+                  <integer>-389</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -2624,7 +2624,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-516</string>
+                  <integer>-516</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -2632,7 +2632,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-644</string>
+                  <integer>-644</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -2640,7 +2640,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-707</string>
+                  <integer>-707</integer>
                   <key>y</key>
                   <integer>342</integer>
                 </dict>
@@ -2650,7 +2650,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-707</string>
+                  <integer>-707</integer>
                   <key>y</key>
                   <integer>217</integer>
                 </dict>
@@ -2658,7 +2658,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-707</string>
+                  <integer>-707</integer>
                   <key>y</key>
                   <integer>112</integer>
                 </dict>
@@ -2666,7 +2666,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-656</string>
+                  <integer>-656</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -2676,7 +2676,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-479</string>
+                  <integer>-479</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -2686,7 +2686,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-427</string>
+                  <integer>-427</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -2696,7 +2696,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-427</string>
+                  <integer>-427</integer>
                   <key>y</key>
                   <integer>124</integer>
                 </dict>
@@ -2706,7 +2706,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-479</string>
+                  <integer>-479</integer>
                   <key>y</key>
                   <integer>124</integer>
                 </dict>
@@ -2714,7 +2714,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-540</string>
+                  <integer>-540</integer>
                   <key>y</key>
                   <integer>124</integer>
                 </dict>
@@ -2722,7 +2722,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-553</string>
+                  <integer>-553</integer>
                   <key>y</key>
                   <integer>171</integer>
                 </dict>
@@ -2732,7 +2732,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-553</string>
+                  <integer>-553</integer>
                   <key>y</key>
                   <integer>217</integer>
                 </dict>
@@ -2740,7 +2740,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-553</string>
+                  <integer>-553</integer>
                   <key>y</key>
                   <integer>280</integer>
                 </dict>
@@ -2748,7 +2748,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-535</string>
+                  <integer>-535</integer>
                   <key>y</key>
                   <integer>306</integer>
                 </dict>
@@ -2758,7 +2758,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-496</string>
+                  <integer>-496</integer>
                   <key>y</key>
                   <integer>306</integer>
                 </dict>
@@ -2766,7 +2766,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-463</string>
+                  <integer>-463</integer>
                   <key>y</key>
                   <integer>306</integer>
                 </dict>
@@ -2774,7 +2774,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-445</string>
+                  <integer>-445</integer>
                   <key>y</key>
                   <integer>280</integer>
                 </dict>
@@ -2784,7 +2784,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-445</string>
+                  <integer>-445</integer>
                   <key>y</key>
                   <integer>217</integer>
                 </dict>
@@ -2794,7 +2794,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-445</string>
+                  <integer>-445</integer>
                   <key>y</key>
                   <integer>198</integer>
                 </dict>
@@ -2804,7 +2804,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-341</string>
+                  <integer>-341</integer>
                   <key>y</key>
                   <integer>198</integer>
                 </dict>
@@ -2814,7 +2814,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-341</string>
+                  <integer>-341</integer>
                   <key>y</key>
                   <integer>237</integer>
                 </dict>
@@ -2829,7 +2829,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-395</string>
+                  <integer>-395</integer>
                   <key>y</key>
                   <integer>198</integer>
                 </dict>
@@ -2839,7 +2839,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-291</string>
+                  <integer>-291</integer>
                   <key>y</key>
                   <integer>198</integer>
                 </dict>
@@ -2849,7 +2849,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-291</string>
+                  <integer>-291</integer>
                   <key>y</key>
                   <integer>217</integer>
                 </dict>
@@ -2857,7 +2857,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-291</string>
+                  <integer>-291</integer>
                   <key>y</key>
                   <integer>280</integer>
                 </dict>
@@ -2865,7 +2865,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-266</string>
+                  <integer>-266</integer>
                   <key>y</key>
                   <integer>306</integer>
                 </dict>
@@ -2875,7 +2875,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-227</string>
+                  <integer>-227</integer>
                   <key>y</key>
                   <integer>306</integer>
                 </dict>
@@ -2883,7 +2883,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-193</string>
+                  <integer>-193</integer>
                   <key>y</key>
                   <integer>306</integer>
                 </dict>
@@ -2891,7 +2891,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-173</string>
+                  <integer>-173</integer>
                   <key>y</key>
                   <string>-0.0001290491718</string>
                 </dict>
@@ -2901,7 +2901,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-173</string>
+                  <integer>-173</integer>
                   <key>y</key>
                   <integer>245</integer>
                 </dict>
@@ -2909,7 +2909,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-173</string>
+                  <integer>-173</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -2917,7 +2917,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-334</string>
+                  <integer>-334</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -2927,7 +2927,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-334</string>
+                  <integer>-334</integer>
                   <key>y</key>
                   <integer>12</integer>
                 </dict>
@@ -2935,9 +2935,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-334</string>
+                  <integer>-334</integer>
                   <key>y</key>
-                  <string>-63</string>
+                  <integer>-63</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -2945,7 +2945,7 @@
                   <key>x</key>
                   <string>-270.7931034482759</string>
                   <key>y</key>
-                  <string>-137</string>
+                  <integer>-137</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -2953,25 +2953,25 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-139</string>
+                  <integer>-139</integer>
                   <key>y</key>
-                  <string>-137</string>
+                  <integer>-137</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-79</string>
+                  <integer>-79</integer>
                   <key>y</key>
-                  <string>-137</string>
+                  <integer>-137</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-37</string>
+                  <integer>-37</integer>
                   <key>y</key>
-                  <string>-126</string>
+                  <integer>-126</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -2979,9 +2979,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2</string>
+                  <integer>-2</integer>
                   <key>y</key>
-                  <string>-101</string>
+                  <integer>-101</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -2989,7 +2989,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2</string>
+                  <integer>-2</integer>
                   <key>y</key>
                   <integer>29</integer>
                 </dict>
@@ -2997,7 +2997,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-33</string>
+                  <integer>-33</integer>
                   <key>y</key>
                   <integer>7</integer>
                 </dict>
@@ -3005,9 +3005,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-90</string>
+                  <integer>-90</integer>
                   <key>y</key>
-                  <string>-13</string>
+                  <integer>-13</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -3015,9 +3015,9 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-139</string>
+                  <integer>-139</integer>
                   <key>y</key>
-                  <string>-13</string>
+                  <integer>-13</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -3025,13 +3025,13 @@
                   <key>x</key>
                   <string>-170.0879120879121</string>
                   <key>y</key>
-                  <string>-13</string>
+                  <integer>-13</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-180</string>
+                  <integer>-180</integer>
                   <key>y</key>
                   <string>-2.000000000000002</string>
                 </dict>
@@ -3041,7 +3041,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-180</string>
+                  <integer>-180</integer>
                   <key>y</key>
                   <integer>12</integer>
                 </dict>
@@ -3057,7 +3057,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-19</string>
+                  <integer>-19</integer>
                   <key>y</key>
                   <integer>157</integer>
                 </dict>
@@ -3067,7 +3067,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-19</string>
+                  <integer>-19</integer>
                   <key>y</key>
                   <integer>295</integer>
                 </dict>
@@ -3075,7 +3075,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-19</string>
+                  <integer>-19</integer>
                   <key>y</key>
                   <integer>368</integer>
                 </dict>
@@ -3093,7 +3093,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-227</string>
+                  <integer>-227</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -3101,7 +3101,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-346</string>
+                  <integer>-346</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -3109,7 +3109,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-395</string>
+                  <integer>-395</integer>
                   <key>y</key>
                   <integer>350</integer>
                 </dict>
@@ -3119,7 +3119,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-395</string>
+                  <integer>-395</integer>
                   <key>y</key>
                   <integer>237</integer>
                 </dict>
@@ -3132,7 +3132,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-347</string>
+                  <integer>-347</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -3140,7 +3140,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-395</string>
+                  <integer>-395</integer>
                   <key>y</key>
                   <integer>350</integer>
                 </dict>
@@ -3150,7 +3150,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-395</string>
+                  <integer>-395</integer>
                   <key>y</key>
                   <integer>237</integer>
                 </dict>
@@ -3160,7 +3160,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-395</string>
+                  <integer>-395</integer>
                   <key>y</key>
                   <integer>198</integer>
                 </dict>
@@ -3170,7 +3170,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-291</string>
+                  <integer>-291</integer>
                   <key>y</key>
                   <integer>198</integer>
                 </dict>
@@ -3180,7 +3180,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-291</string>
+                  <integer>-291</integer>
                   <key>y</key>
                   <integer>217</integer>
                 </dict>
@@ -3188,7 +3188,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-291</string>
+                  <integer>-291</integer>
                   <key>y</key>
                   <integer>280</integer>
                 </dict>
@@ -3196,7 +3196,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-273</string>
+                  <integer>-273</integer>
                   <key>y</key>
                   <integer>306</integer>
                 </dict>
@@ -3206,7 +3206,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-240</string>
+                  <integer>-240</integer>
                   <key>y</key>
                   <integer>306</integer>
                 </dict>
@@ -3214,7 +3214,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-201</string>
+                  <integer>-201</integer>
                   <key>y</key>
                   <integer>306</integer>
                 </dict>
@@ -3222,7 +3222,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-183</string>
+                  <integer>-183</integer>
                   <key>y</key>
                   <integer>280</integer>
                 </dict>
@@ -3232,7 +3232,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-183</string>
+                  <integer>-183</integer>
                   <key>y</key>
                   <integer>217</integer>
                 </dict>
@@ -3240,7 +3240,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-183</string>
+                  <integer>-183</integer>
                   <key>y</key>
                   <integer>171</integer>
                 </dict>
@@ -3248,7 +3248,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-196</string>
+                  <integer>-196</integer>
                   <key>y</key>
                   <integer>124</integer>
                 </dict>
@@ -3258,7 +3258,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-257</string>
+                  <integer>-257</integer>
                   <key>y</key>
                   <integer>124</integer>
                 </dict>
@@ -3268,7 +3268,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-309</string>
+                  <integer>-309</integer>
                   <key>y</key>
                   <integer>124</integer>
                 </dict>
@@ -3278,7 +3278,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-309</string>
+                  <integer>-309</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -3288,7 +3288,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-257</string>
+                  <integer>-257</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -3296,7 +3296,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-80</string>
+                  <integer>-80</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -3304,7 +3304,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-29</string>
+                  <integer>-29</integer>
                   <key>y</key>
                   <integer>112</integer>
                 </dict>
@@ -3314,7 +3314,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-29</string>
+                  <integer>-29</integer>
                   <key>y</key>
                   <integer>217</integer>
                 </dict>
@@ -3322,7 +3322,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-29</string>
+                  <integer>-29</integer>
                   <key>y</key>
                   <integer>342</integer>
                 </dict>
@@ -3330,7 +3330,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-92</string>
+                  <integer>-92</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -3340,7 +3340,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-220</string>
+                  <integer>-220</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -3355,7 +3355,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>674</integer>
                 </dict>
@@ -3365,7 +3365,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>550</integer>
                 </dict>
@@ -3769,7 +3769,7 @@
                   <key>x</key>
                   <integer>435</integer>
                   <key>y</key>
-                  <string>-83</string>
+                  <integer>-83</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -3777,7 +3777,7 @@
                   <key>x</key>
                   <integer>500</integer>
                   <key>y</key>
-                  <string>-137</string>
+                  <integer>-137</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -3787,7 +3787,7 @@
                   <key>x</key>
                   <integer>624</integer>
                   <key>y</key>
-                  <string>-137</string>
+                  <integer>-137</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -3795,7 +3795,7 @@
                   <key>x</key>
                   <integer>690</integer>
                   <key>y</key>
-                  <string>-137</string>
+                  <integer>-137</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -3803,7 +3803,7 @@
                   <key>x</key>
                   <integer>732</integer>
                   <key>y</key>
-                  <string>-126</string>
+                  <integer>-126</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -3813,7 +3813,7 @@
                   <key>x</key>
                   <integer>767</integer>
                   <key>y</key>
-                  <string>-101</string>
+                  <integer>-101</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -3839,7 +3839,7 @@
                   <key>x</key>
                   <integer>683</integer>
                   <key>y</key>
-                  <string>-13</string>
+                  <integer>-13</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -3849,7 +3849,7 @@
                   <key>x</key>
                   <integer>637</integer>
                   <key>y</key>
-                  <string>-13</string>
+                  <integer>-13</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -3857,7 +3857,7 @@
                   <key>x</key>
                   <integer>608</integer>
                   <key>y</key>
-                  <string>-13</string>
+                  <integer>-13</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -3865,7 +3865,7 @@
                   <key>x</key>
                   <integer>589</integer>
                   <key>y</key>
-                  <string>-2</string>
+                  <integer>-2</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>

--- a/Source Files/Biryani-Bold.ufo/glyphs/llV_ocalic-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/llV_ocalic-deva.glif
@@ -123,7 +123,7 @@
                   <key>x</key>
                   <integer>597</integer>
                   <key>y</key>
-                  <string>-223</string>
+                  <integer>-223</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -131,7 +131,7 @@
                   <key>x</key>
                   <integer>564</integer>
                   <key>y</key>
-                  <string>-207</string>
+                  <integer>-207</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -141,7 +141,7 @@
                   <key>x</key>
                   <integer>564</integer>
                   <key>y</key>
-                  <string>-160</string>
+                  <integer>-160</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -149,7 +149,7 @@
                   <key>x</key>
                   <integer>564</integer>
                   <key>y</key>
-                  <string>-127</string>
+                  <integer>-127</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -157,7 +157,7 @@
                   <key>x</key>
                   <integer>578</integer>
                   <key>y</key>
-                  <string>-104</string>
+                  <integer>-104</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -167,7 +167,7 @@
                   <key>x</key>
                   <integer>605</integer>
                   <key>y</key>
-                  <string>-89</string>
+                  <integer>-89</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -177,7 +177,7 @@
                   <key>x</key>
                   <integer>582</integer>
                   <key>y</key>
-                  <string>-92</string>
+                  <integer>-92</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -185,7 +185,7 @@
                   <key>x</key>
                   <integer>593</integer>
                   <key>y</key>
-                  <string>-95</string>
+                  <integer>-95</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -193,7 +193,7 @@
                   <key>x</key>
                   <integer>614</integer>
                   <key>y</key>
-                  <string>-97</string>
+                  <integer>-97</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -203,7 +203,7 @@
                   <key>x</key>
                   <integer>631</integer>
                   <key>y</key>
-                  <string>-97</string>
+                  <integer>-97</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -211,7 +211,7 @@
                   <key>x</key>
                   <integer>655</integer>
                   <key>y</key>
-                  <string>-97</string>
+                  <integer>-97</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -219,7 +219,7 @@
                   <key>x</key>
                   <integer>670</integer>
                   <key>y</key>
-                  <string>-94</string>
+                  <integer>-94</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -229,7 +229,7 @@
                   <key>x</key>
                   <integer>682</integer>
                   <key>y</key>
-                  <string>-91</string>
+                  <integer>-91</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -239,7 +239,7 @@
                   <key>x</key>
                   <integer>682</integer>
                   <key>y</key>
-                  <string>-44</string>
+                  <integer>-44</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -247,7 +247,7 @@
                   <key>x</key>
                   <integer>665</integer>
                   <key>y</key>
-                  <string>-49</string>
+                  <integer>-49</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -255,7 +255,7 @@
                   <key>x</key>
                   <integer>648</integer>
                   <key>y</key>
-                  <string>-53</string>
+                  <integer>-53</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -265,7 +265,7 @@
                   <key>x</key>
                   <integer>630</integer>
                   <key>y</key>
-                  <string>-53</string>
+                  <integer>-53</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -273,7 +273,7 @@
                   <key>x</key>
                   <integer>561</integer>
                   <key>y</key>
-                  <string>-53</string>
+                  <integer>-53</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -281,7 +281,7 @@
                   <key>x</key>
                   <integer>538</integer>
                   <key>y</key>
-                  <string>-24</string>
+                  <integer>-24</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -485,7 +485,7 @@
                   <key>x</key>
                   <integer>484</integer>
                   <key>y</key>
-                  <string>-29</string>
+                  <integer>-29</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -493,7 +493,7 @@
                   <key>x</key>
                   <integer>510</integer>
                   <key>y</key>
-                  <string>-69</string>
+                  <integer>-69</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -503,7 +503,7 @@
                   <key>x</key>
                   <integer>564</integer>
                   <key>y</key>
-                  <string>-87</string>
+                  <integer>-87</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -513,7 +513,7 @@
                   <key>x</key>
                   <integer>559</integer>
                   <key>y</key>
-                  <string>-69</string>
+                  <integer>-69</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -521,7 +521,7 @@
                   <key>x</key>
                   <integer>525</integer>
                   <key>y</key>
-                  <string>-87</string>
+                  <integer>-87</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -529,7 +529,7 @@
                   <key>x</key>
                   <integer>510</integer>
                   <key>y</key>
-                  <string>-119</string>
+                  <integer>-119</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -539,7 +539,7 @@
                   <key>x</key>
                   <integer>510</integer>
                   <key>y</key>
-                  <string>-160</string>
+                  <integer>-160</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -547,7 +547,7 @@
                   <key>x</key>
                   <integer>510</integer>
                   <key>y</key>
-                  <string>-235</string>
+                  <integer>-235</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -555,7 +555,7 @@
                   <key>x</key>
                   <integer>556</integer>
                   <key>y</key>
-                  <string>-267</string>
+                  <integer>-267</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -565,7 +565,7 @@
                   <key>x</key>
                   <integer>652</integer>
                   <key>y</key>
-                  <string>-267</string>
+                  <integer>-267</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -573,7 +573,7 @@
                   <key>x</key>
                   <integer>685</integer>
                   <key>y</key>
-                  <string>-267</string>
+                  <integer>-267</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -581,7 +581,7 @@
                   <key>x</key>
                   <integer>719</integer>
                   <key>y</key>
-                  <string>-261</string>
+                  <integer>-261</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -591,7 +591,7 @@
                   <key>x</key>
                   <integer>752</integer>
                   <key>y</key>
-                  <string>-243</string>
+                  <integer>-243</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -601,7 +601,7 @@
                   <key>x</key>
                   <integer>752</integer>
                   <key>y</key>
-                  <string>-192</string>
+                  <integer>-192</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -609,7 +609,7 @@
                   <key>x</key>
                   <integer>719</integer>
                   <key>y</key>
-                  <string>-215</string>
+                  <integer>-215</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -617,7 +617,7 @@
                   <key>x</key>
                   <integer>687</integer>
                   <key>y</key>
-                  <string>-223</string>
+                  <integer>-223</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -627,7 +627,7 @@
                   <key>x</key>
                   <integer>652</integer>
                   <key>y</key>
-                  <string>-223</string>
+                  <integer>-223</integer>
                 </dict>
               </array>
             </dict>
@@ -640,7 +640,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -650,7 +650,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/n.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/n.glif
@@ -103,7 +103,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-941</string>
+                  <integer>-941</integer>
                   <key>y</key>
                   <integer>558</integer>
                 </dict>
@@ -111,7 +111,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1018</string>
+                  <integer>-1018</integer>
                   <key>y</key>
                   <integer>509</integer>
                 </dict>
@@ -121,7 +121,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1068</string>
+                  <integer>-1068</integer>
                   <key>y</key>
                   <integer>451</integer>
                 </dict>
@@ -131,7 +131,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1068</string>
+                  <integer>-1068</integer>
                   <key>y</key>
                   <integer>397</integer>
                 </dict>
@@ -139,7 +139,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1017</string>
+                  <integer>-1017</integer>
                   <key>y</key>
                   <integer>456</integer>
                 </dict>
@@ -147,7 +147,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-945</string>
+                  <integer>-945</integer>
                   <key>y</key>
                   <integer>504</integer>
                 </dict>
@@ -157,7 +157,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-866</string>
+                  <integer>-866</integer>
                   <key>y</key>
                   <integer>504</integer>
                 </dict>
@@ -165,7 +165,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-764</string>
+                  <integer>-764</integer>
                   <key>y</key>
                   <integer>504</integer>
                 </dict>
@@ -173,7 +173,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-731</string>
+                  <integer>-731</integer>
                   <key>y</key>
                   <integer>458</integer>
                 </dict>
@@ -183,7 +183,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-731</string>
+                  <integer>-731</integer>
                   <key>y</key>
                   <integer>330</integer>
                 </dict>
@@ -193,7 +193,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-731</string>
+                  <integer>-731</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -203,7 +203,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-677</string>
+                  <integer>-677</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -213,7 +213,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-677</string>
+                  <integer>-677</integer>
                   <key>y</key>
                   <integer>330</integer>
                 </dict>
@@ -221,7 +221,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-677</string>
+                  <integer>-677</integer>
                   <key>y</key>
                   <integer>499</integer>
                 </dict>
@@ -229,7 +229,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-740</string>
+                  <integer>-740</integer>
                   <key>y</key>
                   <integer>558</integer>
                 </dict>
@@ -239,7 +239,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-866</string>
+                  <integer>-866</integer>
                   <key>y</key>
                   <integer>558</integer>
                 </dict>
@@ -254,7 +254,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1094</string>
+                  <integer>-1094</integer>
                   <key>y</key>
                   <integer>546</integer>
                 </dict>
@@ -264,7 +264,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1094</string>
+                  <integer>-1094</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -274,7 +274,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1040</string>
+                  <integer>-1040</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -284,7 +284,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1040</string>
+                  <integer>-1040</integer>
                   <key>y</key>
                   <integer>546</integer>
                 </dict>
@@ -315,7 +315,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-416</string>
+                  <integer>-416</integer>
                   <key>y</key>
                   <integer>451</integer>
                 </dict>
@@ -325,7 +325,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-416</string>
+                  <integer>-416</integer>
                   <key>y</key>
                   <integer>287</integer>
                 </dict>
@@ -333,7 +333,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-368</string>
+                  <integer>-368</integer>
                   <key>y</key>
                   <integer>342</integer>
                 </dict>
@@ -341,7 +341,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-313</string>
+                  <integer>-313</integer>
                   <key>y</key>
                   <integer>394</integer>
                 </dict>
@@ -351,7 +351,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-247</string>
+                  <integer>-247</integer>
                   <key>y</key>
                   <integer>394</integer>
                 </dict>
@@ -359,7 +359,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-203</string>
+                  <integer>-203</integer>
                   <key>y</key>
                   <integer>394</integer>
                 </dict>
@@ -367,7 +367,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-189</string>
+                  <integer>-189</integer>
                   <key>y</key>
                   <integer>372</integer>
                 </dict>
@@ -377,7 +377,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-189</string>
+                  <integer>-189</integer>
                   <key>y</key>
                   <integer>310</integer>
                 </dict>
@@ -387,7 +387,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-189</string>
+                  <integer>-189</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -423,7 +423,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-74</string>
+                  <integer>-74</integer>
                   <key>y</key>
                   <integer>558</integer>
                 </dict>
@@ -433,7 +433,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-200</string>
+                  <integer>-200</integer>
                   <key>y</key>
                   <integer>558</integer>
                 </dict>
@@ -448,7 +448,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-552</string>
+                  <integer>-552</integer>
                   <key>y</key>
                   <integer>546</integer>
                 </dict>
@@ -458,7 +458,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-552</string>
+                  <integer>-552</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -468,7 +468,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-358</string>
+                  <integer>-358</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -478,7 +478,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-358</string>
+                  <integer>-358</integer>
                   <key>y</key>
                   <integer>546</integer>
                 </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/ng_k_ssa-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/ng_k_ssa-deva.glif
@@ -178,7 +178,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-7</string>
+                  <integer>-7</integer>
                   <key>y</key>
                   <integer>478</integer>
                 </dict>
@@ -188,7 +188,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-7</string>
+                  <integer>-7</integer>
                   <key>y</key>
                   <integer>388</integer>
                 </dict>
@@ -196,7 +196,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-7</string>
+                  <integer>-7</integer>
                   <key>y</key>
                   <integer>309</integer>
                 </dict>
@@ -322,7 +322,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-36</string>
+                  <integer>-36</integer>
                   <key>y</key>
                   <integer>108</integer>
                 </dict>
@@ -507,7 +507,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-60</string>
+                  <integer>-60</integer>
                   <key>y</key>
                   <integer>674</integer>
                 </dict>
@@ -517,7 +517,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-60</string>
+                  <integer>-60</integer>
                   <key>y</key>
                   <integer>550</integer>
                 </dict>
@@ -594,7 +594,7 @@
                   <key>x</key>
                   <integer>139</integer>
                   <key>y</key>
-                  <string>-173</string>
+                  <integer>-173</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -604,7 +604,7 @@
                   <key>x</key>
                   <integer>139</integer>
                   <key>y</key>
-                  <string>-350</string>
+                  <integer>-350</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -614,7 +614,7 @@
                   <key>x</key>
                   <integer>242</integer>
                   <key>y</key>
-                  <string>-350</string>
+                  <integer>-350</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -624,7 +624,7 @@
                   <key>x</key>
                   <integer>242</integer>
                   <key>y</key>
-                  <string>-173</string>
+                  <integer>-173</integer>
                 </dict>
               </array>
             </dict>
@@ -639,7 +639,7 @@
                   <key>x</key>
                   <integer>84</integer>
                   <key>y</key>
-                  <string>-193</string>
+                  <integer>-193</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -647,7 +647,7 @@
                   <key>x</key>
                   <integer>84</integer>
                   <key>y</key>
-                  <string>-144</string>
+                  <integer>-144</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -655,7 +655,7 @@
                   <key>x</key>
                   <integer>258</integer>
                   <key>y</key>
-                  <string>-146</string>
+                  <integer>-146</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -665,7 +665,7 @@
                   <key>x</key>
                   <integer>258</integer>
                   <key>y</key>
-                  <string>-3</string>
+                  <integer>-3</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -705,7 +705,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-51</string>
+                  <integer>-51</integer>
                   <key>y</key>
                   <integer>82</integer>
                 </dict>
@@ -715,7 +715,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-51</string>
+                  <integer>-51</integer>
                   <key>y</key>
                   <integer>5</integer>
                 </dict>
@@ -725,9 +725,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-51</string>
+                  <integer>-51</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -737,7 +737,7 @@
                   <key>x</key>
                   <integer>91</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -807,15 +807,15 @@
                   <key>x</key>
                   <integer>126</integer>
                   <key>y</key>
-                  <string>-72</string>
+                  <integer>-72</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-58</string>
+                  <integer>-58</integer>
                   <key>y</key>
-                  <string>-57</string>
+                  <integer>-57</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -823,17 +823,17 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-58</string>
+                  <integer>-58</integer>
                   <key>y</key>
-                  <string>-202</string>
+                  <integer>-202</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-58</string>
+                  <integer>-58</integer>
                   <key>y</key>
-                  <string>-309</string>
+                  <integer>-309</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -841,7 +841,7 @@
                   <key>x</key>
                   <integer>29</integer>
                   <key>y</key>
-                  <string>-332</string>
+                  <integer>-332</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -851,7 +851,7 @@
                   <key>x</key>
                   <integer>85</integer>
                   <key>y</key>
-                  <string>-332</string>
+                  <integer>-332</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -861,7 +861,7 @@
                   <key>x</key>
                   <integer>89</integer>
                   <key>y</key>
-                  <string>-332</string>
+                  <integer>-332</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -869,7 +869,7 @@
                   <key>x</key>
                   <integer>125</integer>
                   <key>y</key>
-                  <string>-332</string>
+                  <integer>-332</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -887,7 +887,7 @@
                   <key>x</key>
                   <integer>156</integer>
                   <key>y</key>
-                  <string>-319</string>
+                  <integer>-319</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -897,7 +897,7 @@
                   <key>x</key>
                   <integer>156</integer>
                   <key>y</key>
-                  <string>-207</string>
+                  <integer>-207</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -913,7 +913,7 @@
                   <key>x</key>
                   <real>0.0</real>
                   <key>y</key>
-                  <string>-218</string>
+                  <integer>-218</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -923,7 +923,7 @@
                   <key>x</key>
                   <integer>121</integer>
                   <key>y</key>
-                  <string>-218</string>
+                  <integer>-218</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -933,7 +933,7 @@
                   <key>x</key>
                   <integer>117</integer>
                   <key>y</key>
-                  <string>-218</string>
+                  <integer>-218</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -941,7 +941,7 @@
                   <key>x</key>
                   <integer>96</integer>
                   <key>y</key>
-                  <string>-218</string>
+                  <integer>-218</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -949,7 +949,7 @@
                   <key>x</key>
                   <integer>84</integer>
                   <key>y</key>
-                  <string>-209</string>
+                  <integer>-209</integer>
                 </dict>
               </array>
             </dict>
@@ -974,7 +974,7 @@
                   <key>x</key>
                   <integer>313</integer>
                   <key>y</key>
-                  <string>-316</string>
+                  <integer>-316</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -984,7 +984,7 @@
                   <key>x</key>
                   <integer>466</integer>
                   <key>y</key>
-                  <string>-316</string>
+                  <integer>-316</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -1009,7 +1009,7 @@
                   <key>x</key>
                   <integer>263</integer>
                   <key>y</key>
-                  <string>-78</string>
+                  <integer>-78</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -1019,7 +1019,7 @@
                   <key>x</key>
                   <integer>263</integer>
                   <key>y</key>
-                  <string>-202</string>
+                  <integer>-202</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -1029,7 +1029,7 @@
                   <key>x</key>
                   <integer>445</integer>
                   <key>y</key>
-                  <string>-202</string>
+                  <integer>-202</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -1039,7 +1039,7 @@
                   <key>x</key>
                   <integer>445</integer>
                   <key>y</key>
-                  <string>-78</string>
+                  <integer>-78</integer>
                 </dict>
               </array>
             </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/nga-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/nga-deva.glif
@@ -83,7 +83,7 @@
               <key>x</key>
               <integer>123</integer>
               <key>y</key>
-              <string>-90</string>
+              <integer>-90</integer>
             </dict>
             <dict>
               <key>name</key>
@@ -116,7 +116,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -126,7 +126,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/nine.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/nine.glif
@@ -183,7 +183,7 @@
                   <key>x</key>
                   <integer>195</integer>
                   <key>y</key>
-                  <string>-15</string>
+                  <integer>-15</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>

--- a/Source Files/Biryani-Bold.ufo/glyphs/nn_ra-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/nn_ra-deva.glif
@@ -84,7 +84,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -94,7 +94,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/nukta-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/nukta-deva.glif
@@ -27,7 +27,7 @@
               <key>x</key>
               <string>-220.8</string>
               <key>y</key>
-              <string>-117</string>
+              <integer>-117</integer>
             </dict>
           </array>
           <key>components</key>
@@ -46,7 +46,7 @@
                   <key>x</key>
                   <string>-277.8</string>
                   <key>y</key>
-                  <string>-117</string>
+                  <integer>-117</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -56,7 +56,7 @@
                   <key>x</key>
                   <string>-220.8</string>
                   <key>y</key>
-                  <string>-173</string>
+                  <integer>-173</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -66,7 +66,7 @@
                   <key>x</key>
                   <string>-163.8</string>
                   <key>y</key>
-                  <string>-117</string>
+                  <integer>-117</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -76,7 +76,7 @@
                   <key>x</key>
                   <string>-220.8</string>
                   <key>y</key>
-                  <string>-60</string>
+                  <integer>-60</integer>
                 </dict>
               </array>
             </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/ny_ca-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/ny_ca-deva.glif
@@ -72,7 +72,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -82,7 +82,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/o.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/o.glif
@@ -107,7 +107,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1122</string>
+                  <integer>-1122</integer>
                   <key>y</key>
                   <integer>562</integer>
                 </dict>
@@ -115,7 +115,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1208</string>
+                  <integer>-1208</integer>
                   <key>y</key>
                   <integer>433</integer>
                 </dict>
@@ -125,7 +125,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1208</string>
+                  <integer>-1208</integer>
                   <key>y</key>
                   <integer>273</integer>
                 </dict>
@@ -133,7 +133,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1208</string>
+                  <integer>-1208</integer>
                   <key>y</key>
                   <integer>112</integer>
                 </dict>
@@ -141,9 +141,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1122</string>
+                  <integer>-1122</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -151,23 +151,23 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-950</string>
+                  <integer>-950</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-778</string>
+                  <integer>-778</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-693</string>
+                  <integer>-693</integer>
                   <key>y</key>
                   <integer>112</integer>
                 </dict>
@@ -177,7 +177,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-693</string>
+                  <integer>-693</integer>
                   <key>y</key>
                   <integer>273</integer>
                 </dict>
@@ -185,7 +185,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-693</string>
+                  <integer>-693</integer>
                   <key>y</key>
                   <integer>433</integer>
                 </dict>
@@ -193,7 +193,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-778</string>
+                  <integer>-778</integer>
                   <key>y</key>
                   <integer>562</integer>
                 </dict>
@@ -203,7 +203,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-950</string>
+                  <integer>-950</integer>
                   <key>y</key>
                   <integer>562</integer>
                 </dict>
@@ -216,7 +216,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-819</string>
+                  <integer>-819</integer>
                   <key>y</key>
                   <integer>508</integer>
                 </dict>
@@ -224,7 +224,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-749</string>
+                  <integer>-749</integer>
                   <key>y</key>
                   <integer>403</integer>
                 </dict>
@@ -234,7 +234,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-749</string>
+                  <integer>-749</integer>
                   <key>y</key>
                   <integer>273</integer>
                 </dict>
@@ -242,7 +242,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-749</string>
+                  <integer>-749</integer>
                   <key>y</key>
                   <integer>143</integer>
                 </dict>
@@ -250,7 +250,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-819</string>
+                  <integer>-819</integer>
                   <key>y</key>
                   <integer>37</integer>
                 </dict>
@@ -260,7 +260,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-950</string>
+                  <integer>-950</integer>
                   <key>y</key>
                   <integer>37</integer>
                 </dict>
@@ -268,7 +268,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1082</string>
+                  <integer>-1082</integer>
                   <key>y</key>
                   <integer>37</integer>
                 </dict>
@@ -276,7 +276,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1152</string>
+                  <integer>-1152</integer>
                   <key>y</key>
                   <integer>143</integer>
                 </dict>
@@ -286,7 +286,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1152</string>
+                  <integer>-1152</integer>
                   <key>y</key>
                   <integer>273</integer>
                 </dict>
@@ -294,7 +294,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1152</string>
+                  <integer>-1152</integer>
                   <key>y</key>
                   <integer>403</integer>
                 </dict>
@@ -302,7 +302,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1082</string>
+                  <integer>-1082</integer>
                   <key>y</key>
                   <integer>508</integer>
                 </dict>
@@ -312,7 +312,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-950</string>
+                  <integer>-950</integer>
                   <key>y</key>
                   <integer>508</integer>
                 </dict>
@@ -333,7 +333,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-599</string>
+                  <integer>-599</integer>
                   <key>y</key>
                   <integer>433</integer>
                 </dict>
@@ -343,7 +343,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-599</string>
+                  <integer>-599</integer>
                   <key>y</key>
                   <integer>273</integer>
                 </dict>
@@ -351,7 +351,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-599</string>
+                  <integer>-599</integer>
                   <key>y</key>
                   <integer>112</integer>
                 </dict>
@@ -361,7 +361,7 @@
                   <key>x</key>
                   <string>-499.666666667</string>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -369,9 +369,9 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-301</string>
+                  <integer>-301</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -379,13 +379,13 @@
                   <key>x</key>
                   <string>-102.229571984</string>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-4</string>
+                  <integer>-4</integer>
                   <key>y</key>
                   <integer>112</integer>
                 </dict>
@@ -395,7 +395,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-4</string>
+                  <integer>-4</integer>
                   <key>y</key>
                   <integer>273</integer>
                 </dict>
@@ -403,7 +403,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-4</string>
+                  <integer>-4</integer>
                   <key>y</key>
                   <integer>433</integer>
                 </dict>
@@ -421,7 +421,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-301</string>
+                  <integer>-301</integer>
                   <key>y</key>
                   <integer>562</integer>
                 </dict>
@@ -442,7 +442,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-200</string>
+                  <integer>-200</integer>
                   <key>y</key>
                   <integer>350</integer>
                 </dict>
@@ -452,7 +452,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-200</string>
+                  <integer>-200</integer>
                   <key>y</key>
                   <integer>273</integer>
                 </dict>
@@ -460,7 +460,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-200</string>
+                  <integer>-200</integer>
                   <key>y</key>
                   <integer>196</integer>
                 </dict>
@@ -478,7 +478,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-301</string>
+                  <integer>-301</integer>
                   <key>y</key>
                   <integer>142</integer>
                 </dict>
@@ -494,7 +494,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-403</string>
+                  <integer>-403</integer>
                   <key>y</key>
                   <integer>196</integer>
                 </dict>
@@ -504,7 +504,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-403</string>
+                  <integer>-403</integer>
                   <key>y</key>
                   <integer>273</integer>
                 </dict>
@@ -512,7 +512,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-403</string>
+                  <integer>-403</integer>
                   <key>y</key>
                   <integer>350</integer>
                 </dict>
@@ -530,7 +530,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-301</string>
+                  <integer>-301</integer>
                   <key>y</key>
                   <integer>403</integer>
                 </dict>
@@ -579,7 +579,7 @@
                   <key>x</key>
                   <integer>176</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -589,7 +589,7 @@
                   <key>x</key>
                   <integer>348</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -597,7 +597,7 @@
                   <key>x</key>
                   <integer>520</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>

--- a/Source Files/Biryani-Bold.ufo/glyphs/ogonek.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/ogonek.glif
@@ -43,7 +43,7 @@
           <key>x</key>
           <integer>392</integer>
           <key>y</key>
-          <string>-188</string>
+          <integer>-188</integer>
         </dict>
       </array>
       <key>com.typemytype.robofont.layerData</key>
@@ -75,7 +75,7 @@
                   <key>x</key>
                   <integer>357</integer>
                   <key>y</key>
-                  <string>-223</string>
+                  <integer>-223</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -83,7 +83,7 @@
                   <key>x</key>
                   <integer>374</integer>
                   <key>y</key>
-                  <string>-220</string>
+                  <integer>-220</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -93,7 +93,7 @@
                   <key>x</key>
                   <integer>392</integer>
                   <key>y</key>
-                  <string>-212</string>
+                  <integer>-212</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -103,7 +103,7 @@
                   <key>x</key>
                   <integer>392</integer>
                   <key>y</key>
-                  <string>-164</string>
+                  <integer>-164</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -111,7 +111,7 @@
                   <key>x</key>
                   <integer>373</integer>
                   <key>y</key>
-                  <string>-174</string>
+                  <integer>-174</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -119,7 +119,7 @@
                   <key>x</key>
                   <integer>355</integer>
                   <key>y</key>
-                  <string>-176</string>
+                  <integer>-176</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -129,7 +129,7 @@
                   <key>x</key>
                   <integer>340</integer>
                   <key>y</key>
-                  <string>-176</string>
+                  <integer>-176</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -137,7 +137,7 @@
                   <key>x</key>
                   <integer>304</integer>
                   <key>y</key>
-                  <string>-176</string>
+                  <integer>-176</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -145,7 +145,7 @@
                   <key>x</key>
                   <integer>289</integer>
                   <key>y</key>
-                  <string>-157</string>
+                  <integer>-157</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -155,7 +155,7 @@
                   <key>x</key>
                   <integer>289</integer>
                   <key>y</key>
-                  <string>-135</string>
+                  <integer>-135</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -163,7 +163,7 @@
                   <key>x</key>
                   <integer>289</integer>
                   <key>y</key>
-                  <string>-85</string>
+                  <integer>-85</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -171,7 +171,7 @@
                   <key>x</key>
                   <integer>336</integer>
                   <key>y</key>
-                  <string>-44</string>
+                  <integer>-44</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -199,7 +199,7 @@
                   <key>x</key>
                   <integer>273</integer>
                   <key>y</key>
-                  <string>-46</string>
+                  <integer>-46</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -207,7 +207,7 @@
                   <key>x</key>
                   <integer>238</integer>
                   <key>y</key>
-                  <string>-88</string>
+                  <integer>-88</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -217,7 +217,7 @@
                   <key>x</key>
                   <integer>238</integer>
                   <key>y</key>
-                  <string>-140</string>
+                  <integer>-140</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -225,7 +225,7 @@
                   <key>x</key>
                   <integer>238</integer>
                   <key>y</key>
-                  <string>-188</string>
+                  <integer>-188</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -233,7 +233,7 @@
                   <key>x</key>
                   <integer>271</integer>
                   <key>y</key>
-                  <string>-223</string>
+                  <integer>-223</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -243,7 +243,7 @@
                   <key>x</key>
                   <integer>340</integer>
                   <key>y</key>
-                  <string>-223</string>
+                  <integer>-223</integer>
                 </dict>
               </array>
             </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/oslash.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/oslash.glif
@@ -33,7 +33,7 @@
                 <integer>0</integer>
                 <integer>0</integer>
                 <integer>1</integer>
-                <string>-10</string>
+                <integer>-10</integer>
                 <integer>0</integer>
               </array>
             </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/p.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/p.glif
@@ -91,7 +91,7 @@
                   <key>x</key>
                   <integer>143</integer>
                   <key>y</key>
-                  <string>-234</string>
+                  <integer>-234</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -101,7 +101,7 @@
                   <key>x</key>
                   <integer>197</integer>
                   <key>y</key>
-                  <string>-234</string>
+                  <integer>-234</integer>
                 </dict>
               </array>
             </dict>
@@ -298,7 +298,7 @@
                   <key>x</key>
                   <integer>290</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -308,7 +308,7 @@
                   <key>x</key>
                   <integer>361</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -316,7 +316,7 @@
                   <key>x</key>
                   <integer>502</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>

--- a/Source Files/Biryani-Bold.ufo/glyphs/paragraph.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/paragraph.glif
@@ -118,7 +118,7 @@
                   <key>x</key>
                   <integer>401</integer>
                   <key>y</key>
-                  <string>-100</string>
+                  <integer>-100</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -128,7 +128,7 @@
                   <key>x</key>
                   <integer>457</integer>
                   <key>y</key>
-                  <string>-100</string>
+                  <integer>-100</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -158,7 +158,7 @@
                   <key>x</key>
                   <integer>561</integer>
                   <key>y</key>
-                  <string>-100</string>
+                  <integer>-100</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -168,7 +168,7 @@
                   <key>x</key>
                   <integer>617</integer>
                   <key>y</key>
-                  <string>-100</string>
+                  <integer>-100</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>

--- a/Source Files/Biryani-Bold.ufo/glyphs/parenright.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/parenright.glif
@@ -113,7 +113,7 @@
                   <key>x</key>
                   <integer>126</integer>
                   <key>y</key>
-                  <string>-45</string>
+                  <integer>-45</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -123,7 +123,7 @@
                   <key>x</key>
                   <integer>84</integer>
                   <key>y</key>
-                  <string>-102</string>
+                  <integer>-102</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -133,7 +133,7 @@
                   <key>x</key>
                   <integer>120</integer>
                   <key>y</key>
-                  <string>-129</string>
+                  <integer>-129</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -141,7 +141,7 @@
                   <key>x</key>
                   <integer>166</integer>
                   <key>y</key>
-                  <string>-74</string>
+                  <integer>-74</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>

--- a/Source Files/Biryani-Bold.ufo/glyphs/partialdiff.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/partialdiff.glif
@@ -61,7 +61,7 @@
                   <key>x</key>
                   <integer>468</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -323,7 +323,7 @@
                   <key>x</key>
                   <integer>163</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -333,7 +333,7 @@
                   <key>x</key>
                   <integer>309</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
               </array>
             </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/pha-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/pha-deva.glif
@@ -391,7 +391,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-30</string>
+                  <integer>-30</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -401,7 +401,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-30</string>
+                  <integer>-30</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/product.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/product.glif
@@ -57,7 +57,7 @@
                   <key>x</key>
                   <integer>120</integer>
                   <key>y</key>
-                  <string>-237</string>
+                  <integer>-237</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -67,7 +67,7 @@
                   <key>x</key>
                   <integer>176</integer>
                   <key>y</key>
-                  <string>-237</string>
+                  <integer>-237</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -102,7 +102,7 @@
                   <key>x</key>
                   <integer>599</integer>
                   <key>y</key>
-                  <string>-237</string>
+                  <integer>-237</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -112,7 +112,7 @@
                   <key>x</key>
                   <integer>655</integer>
                   <key>y</key>
-                  <string>-237</string>
+                  <integer>-237</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>

--- a/Source Files/Biryani-Bold.ufo/glyphs/q.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/q.glif
@@ -77,7 +77,7 @@
                   <key>x</key>
                   <integer>172</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -87,7 +87,7 @@
                   <key>x</key>
                   <integer>313</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -95,7 +95,7 @@
                   <key>x</key>
                   <integer>384</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -324,7 +324,7 @@
                   <key>x</key>
                   <integer>477</integer>
                   <key>y</key>
-                  <string>-234</string>
+                  <integer>-234</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -334,7 +334,7 @@
                   <key>x</key>
                   <integer>531</integer>
                   <key>y</key>
-                  <string>-234</string>
+                  <integer>-234</integer>
                 </dict>
               </array>
             </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/ra-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/ra-deva.glif
@@ -61,7 +61,7 @@
           <key>x</key>
           <integer>442</integer>
           <key>y</key>
-          <string>-4</string>
+          <integer>-4</integer>
         </dict>
       </array>
       <key>com.typemytype.robofont.layerData</key>

--- a/Source Files/Biryani-Bold.ufo/glyphs/ra_uM_atra-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/ra_uM_atra-deva.glif
@@ -82,7 +82,7 @@
           <key>x</key>
           <integer>442</integer>
           <key>y</key>
-          <string>-4</string>
+          <integer>-4</integer>
         </dict>
       </array>
       <key>com.typemytype.robofont.layerData</key>

--- a/Source Files/Biryani-Bold.ufo/glyphs/ra_uuM_atra-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/ra_uuM_atra-deva.glif
@@ -90,7 +90,7 @@
           <key>x</key>
           <integer>442</integer>
           <key>y</key>
-          <string>-4</string>
+          <integer>-4</integer>
         </dict>
       </array>
       <key>com.typemytype.robofont.layerData</key>

--- a/Source Files/Biryani-Bold.ufo/glyphs/rrV_ocalic-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/rrV_ocalic-deva.glif
@@ -389,7 +389,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -399,7 +399,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -641,7 +641,7 @@
                   <key>x</key>
                   <integer>611</integer>
                   <key>y</key>
-                  <string>-21</string>
+                  <integer>-21</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -651,7 +651,7 @@
                   <key>x</key>
                   <integer>733</integer>
                   <key>y</key>
-                  <string>-21</string>
+                  <integer>-21</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -661,7 +661,7 @@
                   <key>x</key>
                   <integer>778</integer>
                   <key>y</key>
-                  <string>-21</string>
+                  <integer>-21</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -720,7 +720,7 @@
                   <key>x</key>
                   <integer>660</integer>
                   <key>y</key>
-                  <string>-40</string>
+                  <integer>-40</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -728,7 +728,7 @@
                   <key>x</key>
                   <integer>690</integer>
                   <key>y</key>
-                  <string>-21</string>
+                  <integer>-21</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -738,7 +738,7 @@
                   <key>x</key>
                   <integer>738</integer>
                   <key>y</key>
-                  <string>-21</string>
+                  <integer>-21</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -748,7 +748,7 @@
                   <key>x</key>
                   <integer>758</integer>
                   <key>y</key>
-                  <string>-21</string>
+                  <integer>-21</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -784,7 +784,7 @@
                   <key>x</key>
                   <integer>606</integer>
                   <key>y</key>
-                  <string>-18</string>
+                  <integer>-18</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -794,7 +794,7 @@
                   <key>x</key>
                   <integer>606</integer>
                   <key>y</key>
-                  <string>-84</string>
+                  <integer>-84</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -802,7 +802,7 @@
                   <key>x</key>
                   <integer>606</integer>
                   <key>y</key>
-                  <string>-159</string>
+                  <integer>-159</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -810,7 +810,7 @@
                   <key>x</key>
                   <integer>652</integer>
                   <key>y</key>
-                  <string>-191</string>
+                  <integer>-191</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -820,7 +820,7 @@
                   <key>x</key>
                   <integer>748</integer>
                   <key>y</key>
-                  <string>-191</string>
+                  <integer>-191</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -828,7 +828,7 @@
                   <key>x</key>
                   <integer>781</integer>
                   <key>y</key>
-                  <string>-191</string>
+                  <integer>-191</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -836,7 +836,7 @@
                   <key>x</key>
                   <integer>815</integer>
                   <key>y</key>
-                  <string>-185</string>
+                  <integer>-185</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -846,7 +846,7 @@
                   <key>x</key>
                   <integer>848</integer>
                   <key>y</key>
-                  <string>-167</string>
+                  <integer>-167</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -856,7 +856,7 @@
                   <key>x</key>
                   <integer>848</integer>
                   <key>y</key>
-                  <string>-116</string>
+                  <integer>-116</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -864,7 +864,7 @@
                   <key>x</key>
                   <integer>815</integer>
                   <key>y</key>
-                  <string>-139</string>
+                  <integer>-139</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -872,7 +872,7 @@
                   <key>x</key>
                   <integer>783</integer>
                   <key>y</key>
-                  <string>-147</string>
+                  <integer>-147</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -882,7 +882,7 @@
                   <key>x</key>
                   <integer>748</integer>
                   <key>y</key>
-                  <string>-147</string>
+                  <integer>-147</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -890,7 +890,7 @@
                   <key>x</key>
                   <integer>693</integer>
                   <key>y</key>
-                  <string>-147</string>
+                  <integer>-147</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -898,7 +898,7 @@
                   <key>x</key>
                   <integer>660</integer>
                   <key>y</key>
-                  <string>-131</string>
+                  <integer>-131</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -908,7 +908,7 @@
                   <key>x</key>
                   <integer>660</integer>
                   <key>y</key>
-                  <string>-84</string>
+                  <integer>-84</integer>
                 </dict>
               </array>
             </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/s.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/s.glif
@@ -391,7 +391,7 @@
                   <key>x</key>
                   <integer>157</integer>
                   <key>y</key>
-                  <string>-5</string>
+                  <integer>-5</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -399,7 +399,7 @@
                   <key>x</key>
                   <integer>210</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -409,7 +409,7 @@
                   <key>x</key>
                   <integer>284</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -417,7 +417,7 @@
                   <key>x</key>
                   <integer>391</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>

--- a/Source Files/Biryani-Bold.ufo/glyphs/s_r-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/s_r-deva.glif
@@ -403,7 +403,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -413,7 +413,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/section.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/section.glif
@@ -590,7 +590,7 @@
                   <key>x</key>
                   <integer>396</integer>
                   <key>y</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -598,7 +598,7 @@
                   <key>x</key>
                   <integer>359</integer>
                   <key>y</key>
-                  <string>-49</string>
+                  <integer>-49</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -608,7 +608,7 @@
                   <key>x</key>
                   <integer>267</integer>
                   <key>y</key>
-                  <string>-49</string>
+                  <integer>-49</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -616,7 +616,7 @@
                   <key>x</key>
                   <integer>208</integer>
                   <key>y</key>
-                  <string>-49</string>
+                  <integer>-49</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -624,7 +624,7 @@
                   <key>x</key>
                   <integer>156</integer>
                   <key>y</key>
-                  <string>-38</string>
+                  <integer>-38</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -634,7 +634,7 @@
                   <key>x</key>
                   <integer>105</integer>
                   <key>y</key>
-                  <string>-14</string>
+                  <integer>-14</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -644,7 +644,7 @@
                   <key>x</key>
                   <integer>105</integer>
                   <key>y</key>
-                  <string>-72</string>
+                  <integer>-72</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -652,7 +652,7 @@
                   <key>x</key>
                   <integer>157</integer>
                   <key>y</key>
-                  <string>-93</string>
+                  <integer>-93</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -660,7 +660,7 @@
                   <key>x</key>
                   <integer>207</integer>
                   <key>y</key>
-                  <string>-101</string>
+                  <integer>-101</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -670,7 +670,7 @@
                   <key>x</key>
                   <integer>267</integer>
                   <key>y</key>
-                  <string>-101</string>
+                  <integer>-101</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -678,7 +678,7 @@
                   <key>x</key>
                   <integer>382</integer>
                   <key>y</key>
-                  <string>-101</string>
+                  <integer>-101</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -686,7 +686,7 @@
                   <key>x</key>
                   <integer>453</integer>
                   <key>y</key>
-                  <string>-49</string>
+                  <integer>-49</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>

--- a/Source Files/Biryani-Bold.ufo/glyphs/seven.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/seven.glif
@@ -39,7 +39,7 @@
                   <key>x</key>
                   <integer>244</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -109,7 +109,7 @@
                   <key>x</key>
                   <integer>182</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
               </array>
             </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/sh-deva.loclM_A_R_.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/sh-deva.loclM_A_R_.glif
@@ -64,7 +64,7 @@
               <key>x</key>
               <integer>92</integer>
               <key>y</key>
-              <string>-30</string>
+              <integer>-30</integer>
             </dict>
             <dict>
               <key>name</key>
@@ -88,7 +88,7 @@
               <key>x</key>
               <integer>92</integer>
               <key>y</key>
-              <string>-30</string>
+              <integer>-30</integer>
             </dict>
             <dict>
               <key>name</key>
@@ -121,7 +121,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-164</string>
+                  <integer>-164</integer>
                   <key>y</key>
                   <integer>610</integer>
                 </dict>
@@ -131,7 +131,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-164</string>
+                  <integer>-164</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -141,7 +141,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-110</string>
+                  <integer>-110</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -151,7 +151,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-110</string>
+                  <integer>-110</integer>
                   <key>y</key>
                   <integer>610</integer>
                 </dict>
@@ -166,7 +166,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-742</string>
+                  <integer>-742</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -176,7 +176,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-742</string>
+                  <integer>-742</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -209,7 +209,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-329</string>
+                  <integer>-329</integer>
                   <key>y</key>
                   <integer>453</integer>
                 </dict>
@@ -217,7 +217,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-372</string>
+                  <integer>-372</integer>
                   <key>y</key>
                   <integer>517</integer>
                 </dict>
@@ -227,7 +227,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-487</string>
+                  <integer>-487</integer>
                   <key>y</key>
                   <integer>517</integer>
                 </dict>
@@ -235,7 +235,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-597</string>
+                  <integer>-597</integer>
                   <key>y</key>
                   <integer>517</integer>
                 </dict>
@@ -243,7 +243,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-644</string>
+                  <integer>-644</integer>
                   <key>y</key>
                   <integer>454</integer>
                 </dict>
@@ -253,7 +253,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-645</string>
+                  <integer>-645</integer>
                   <key>y</key>
                   <integer>337</integer>
                 </dict>
@@ -263,7 +263,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-645</string>
+                  <integer>-645</integer>
                   <key>y</key>
                   <integer>299</integer>
                 </dict>
@@ -273,7 +273,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-591</string>
+                  <integer>-591</integer>
                   <key>y</key>
                   <integer>299</integer>
                 </dict>
@@ -283,7 +283,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-591</string>
+                  <integer>-591</integer>
                   <key>y</key>
                   <integer>337</integer>
                 </dict>
@@ -291,7 +291,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-590</string>
+                  <integer>-590</integer>
                   <key>y</key>
                   <integer>439</integer>
                 </dict>
@@ -299,7 +299,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-555</string>
+                  <integer>-555</integer>
                   <key>y</key>
                   <integer>473</integer>
                 </dict>
@@ -309,7 +309,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-487</string>
+                  <integer>-487</integer>
                   <key>y</key>
                   <integer>473</integer>
                 </dict>
@@ -317,7 +317,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-408</string>
+                  <integer>-408</integer>
                   <key>y</key>
                   <integer>473</integer>
                 </dict>
@@ -325,7 +325,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-383</string>
+                  <integer>-383</integer>
                   <key>y</key>
                   <integer>440</integer>
                 </dict>
@@ -335,7 +335,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-383</string>
+                  <integer>-383</integer>
                   <key>y</key>
                   <integer>337</integer>
                 </dict>
@@ -343,7 +343,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-384</string>
+                  <integer>-384</integer>
                   <key>y</key>
                   <integer>241</integer>
                 </dict>
@@ -351,7 +351,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-455</string>
+                  <integer>-455</integer>
                   <key>y</key>
                   <integer>181</integer>
                 </dict>
@@ -361,7 +361,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-575</string>
+                  <integer>-575</integer>
                   <key>y</key>
                   <integer>181</integer>
                 </dict>
@@ -371,7 +371,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-665</string>
+                  <integer>-665</integer>
                   <key>y</key>
                   <integer>181</integer>
                 </dict>
@@ -381,7 +381,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-665</string>
+                  <integer>-665</integer>
                   <key>y</key>
                   <integer>137</integer>
                 </dict>
@@ -391,7 +391,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-575</string>
+                  <integer>-575</integer>
                   <key>y</key>
                   <integer>137</integer>
                 </dict>
@@ -399,7 +399,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-427</string>
+                  <integer>-427</integer>
                   <key>y</key>
                   <integer>137</integer>
                 </dict>
@@ -407,7 +407,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-330</string>
+                  <integer>-330</integer>
                   <key>y</key>
                   <integer>220</integer>
                 </dict>
@@ -417,7 +417,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-329</string>
+                  <integer>-329</integer>
                   <key>y</key>
                   <integer>337</integer>
                 </dict>
@@ -432,7 +432,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-643</string>
+                  <integer>-643</integer>
                   <key>y</key>
                   <integer>153</integer>
                 </dict>
@@ -442,9 +442,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-473</string>
+                  <integer>-473</integer>
                   <key>y</key>
-                  <string>-45</string>
+                  <integer>-45</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -452,9 +452,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-437</string>
+                  <integer>-437</integer>
                   <key>y</key>
-                  <string>-15</string>
+                  <integer>-15</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -462,7 +462,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-582</string>
+                  <integer>-582</integer>
                   <key>y</key>
                   <integer>153</integer>
                 </dict>
@@ -477,7 +477,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-514</string>
+                  <integer>-514</integer>
                   <key>y</key>
                   <integer>610</integer>
                 </dict>
@@ -487,7 +487,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-514</string>
+                  <integer>-514</integer>
                   <key>y</key>
                   <integer>490</integer>
                 </dict>
@@ -497,7 +497,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-460</string>
+                  <integer>-460</integer>
                   <key>y</key>
                   <integer>490</integer>
                 </dict>
@@ -507,7 +507,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-460</string>
+                  <integer>-460</integer>
                   <key>y</key>
                   <integer>610</integer>
                 </dict>
@@ -567,7 +567,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -577,7 +577,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -845,7 +845,7 @@
                   <key>x</key>
                   <integer>259</integer>
                   <key>y</key>
-                  <string>-45</string>
+                  <integer>-45</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -855,7 +855,7 @@
                   <key>x</key>
                   <integer>295</integer>
                   <key>y</key>
-                  <string>-15</string>
+                  <integer>-15</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>

--- a/Source Files/Biryani-Bold.ufo/glyphs/sha-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/sha-deva.glif
@@ -77,7 +77,7 @@
               <key>x</key>
               <integer>112</integer>
               <key>y</key>
-              <string>-50</string>
+              <integer>-50</integer>
             </dict>
             <dict>
               <key>name</key>

--- a/Source Files/Biryani-Bold.ufo/glyphs/sha-deva.loclM_A_R_.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/sha-deva.loclM_A_R_.glif
@@ -79,7 +79,7 @@
               <key>x</key>
               <integer>92</integer>
               <key>y</key>
-              <string>-30</string>
+              <integer>-30</integer>
             </dict>
             <dict>
               <key>name</key>
@@ -103,7 +103,7 @@
               <key>x</key>
               <integer>92</integer>
               <key>y</key>
-              <string>-30</string>
+              <integer>-30</integer>
             </dict>
             <dict>
               <key>name</key>
@@ -136,7 +136,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-164</string>
+                  <integer>-164</integer>
                   <key>y</key>
                   <integer>610</integer>
                 </dict>
@@ -146,7 +146,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-164</string>
+                  <integer>-164</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -156,7 +156,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-110</string>
+                  <integer>-110</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -166,7 +166,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-110</string>
+                  <integer>-110</integer>
                   <key>y</key>
                   <integer>610</integer>
                 </dict>
@@ -181,7 +181,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-742</string>
+                  <integer>-742</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -191,7 +191,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-742</string>
+                  <integer>-742</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -224,7 +224,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-329</string>
+                  <integer>-329</integer>
                   <key>y</key>
                   <integer>453</integer>
                 </dict>
@@ -232,7 +232,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-372</string>
+                  <integer>-372</integer>
                   <key>y</key>
                   <integer>517</integer>
                 </dict>
@@ -242,7 +242,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-487</string>
+                  <integer>-487</integer>
                   <key>y</key>
                   <integer>517</integer>
                 </dict>
@@ -250,7 +250,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-597</string>
+                  <integer>-597</integer>
                   <key>y</key>
                   <integer>517</integer>
                 </dict>
@@ -258,7 +258,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-644</string>
+                  <integer>-644</integer>
                   <key>y</key>
                   <integer>454</integer>
                 </dict>
@@ -268,7 +268,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-645</string>
+                  <integer>-645</integer>
                   <key>y</key>
                   <integer>337</integer>
                 </dict>
@@ -278,7 +278,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-645</string>
+                  <integer>-645</integer>
                   <key>y</key>
                   <integer>299</integer>
                 </dict>
@@ -288,7 +288,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-591</string>
+                  <integer>-591</integer>
                   <key>y</key>
                   <integer>299</integer>
                 </dict>
@@ -298,7 +298,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-591</string>
+                  <integer>-591</integer>
                   <key>y</key>
                   <integer>337</integer>
                 </dict>
@@ -306,7 +306,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-590</string>
+                  <integer>-590</integer>
                   <key>y</key>
                   <integer>439</integer>
                 </dict>
@@ -314,7 +314,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-555</string>
+                  <integer>-555</integer>
                   <key>y</key>
                   <integer>473</integer>
                 </dict>
@@ -324,7 +324,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-487</string>
+                  <integer>-487</integer>
                   <key>y</key>
                   <integer>473</integer>
                 </dict>
@@ -332,7 +332,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-408</string>
+                  <integer>-408</integer>
                   <key>y</key>
                   <integer>473</integer>
                 </dict>
@@ -340,7 +340,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-383</string>
+                  <integer>-383</integer>
                   <key>y</key>
                   <integer>440</integer>
                 </dict>
@@ -350,7 +350,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-383</string>
+                  <integer>-383</integer>
                   <key>y</key>
                   <integer>337</integer>
                 </dict>
@@ -358,7 +358,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-384</string>
+                  <integer>-384</integer>
                   <key>y</key>
                   <integer>241</integer>
                 </dict>
@@ -366,7 +366,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-455</string>
+                  <integer>-455</integer>
                   <key>y</key>
                   <integer>181</integer>
                 </dict>
@@ -376,7 +376,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-575</string>
+                  <integer>-575</integer>
                   <key>y</key>
                   <integer>181</integer>
                 </dict>
@@ -386,7 +386,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-665</string>
+                  <integer>-665</integer>
                   <key>y</key>
                   <integer>181</integer>
                 </dict>
@@ -396,7 +396,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-665</string>
+                  <integer>-665</integer>
                   <key>y</key>
                   <integer>137</integer>
                 </dict>
@@ -406,7 +406,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-575</string>
+                  <integer>-575</integer>
                   <key>y</key>
                   <integer>137</integer>
                 </dict>
@@ -414,7 +414,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-427</string>
+                  <integer>-427</integer>
                   <key>y</key>
                   <integer>137</integer>
                 </dict>
@@ -422,7 +422,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-330</string>
+                  <integer>-330</integer>
                   <key>y</key>
                   <integer>220</integer>
                 </dict>
@@ -432,7 +432,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-329</string>
+                  <integer>-329</integer>
                   <key>y</key>
                   <integer>337</integer>
                 </dict>
@@ -447,7 +447,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-643</string>
+                  <integer>-643</integer>
                   <key>y</key>
                   <integer>153</integer>
                 </dict>
@@ -457,9 +457,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-473</string>
+                  <integer>-473</integer>
                   <key>y</key>
-                  <string>-45</string>
+                  <integer>-45</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -467,9 +467,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-437</string>
+                  <integer>-437</integer>
                   <key>y</key>
-                  <string>-15</string>
+                  <integer>-15</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -477,7 +477,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-582</string>
+                  <integer>-582</integer>
                   <key>y</key>
                   <integer>153</integer>
                 </dict>
@@ -492,7 +492,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-514</string>
+                  <integer>-514</integer>
                   <key>y</key>
                   <integer>610</integer>
                 </dict>
@@ -502,7 +502,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-514</string>
+                  <integer>-514</integer>
                   <key>y</key>
                   <integer>490</integer>
                 </dict>
@@ -512,7 +512,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-460</string>
+                  <integer>-460</integer>
                   <key>y</key>
                   <integer>490</integer>
                 </dict>
@@ -522,7 +522,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-460</string>
+                  <integer>-460</integer>
                   <key>y</key>
                   <integer>610</integer>
                 </dict>
@@ -582,7 +582,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -592,7 +592,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -860,7 +860,7 @@
                   <key>x</key>
                   <integer>259</integer>
                   <key>y</key>
-                  <string>-45</string>
+                  <integer>-45</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -870,7 +870,7 @@
                   <key>x</key>
                   <integer>295</integer>
                   <key>y</key>
-                  <string>-15</string>
+                  <integer>-15</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>

--- a/Source Files/Biryani-Bold.ufo/glyphs/six.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/six.glif
@@ -121,7 +121,7 @@
                   <key>x</key>
                   <integer>402</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -131,7 +131,7 @@
                   <key>x</key>
                   <integer>285</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -139,7 +139,7 @@
                   <key>x</key>
                   <integer>147</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>

--- a/Source Files/Biryani-Bold.ufo/glyphs/summation.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/summation.glif
@@ -51,7 +51,7 @@
                   <key>x</key>
                   <integer>124</integer>
                   <key>y</key>
-                  <string>-183</string>
+                  <integer>-183</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -61,7 +61,7 @@
                   <key>x</key>
                   <integer>137</integer>
                   <key>y</key>
-                  <string>-203</string>
+                  <integer>-203</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -101,7 +101,7 @@
                   <key>x</key>
                   <integer>80</integer>
                   <key>y</key>
-                  <string>-185</string>
+                  <integer>-185</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -111,7 +111,7 @@
                   <key>x</key>
                   <integer>80</integer>
                   <key>y</key>
-                  <string>-237</string>
+                  <integer>-237</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -121,7 +121,7 @@
                   <key>x</key>
                   <integer>609</integer>
                   <key>y</key>
-                  <string>-237</string>
+                  <integer>-237</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -131,7 +131,7 @@
                   <key>x</key>
                   <integer>609</integer>
                   <key>y</key>
-                  <string>-183</string>
+                  <integer>-183</integer>
                 </dict>
               </array>
             </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/t.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/t.glif
@@ -73,7 +73,7 @@
                   <key>x</key>
                   <integer>312</integer>
                   <key>y</key>
-                  <string>-13</string>
+                  <integer>-13</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -81,7 +81,7 @@
                   <key>x</key>
                   <integer>330</integer>
                   <key>y</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -91,7 +91,7 @@
                   <key>x</key>
                   <integer>352</integer>
                   <key>y</key>
-                  <string>-5</string>
+                  <integer>-5</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -199,7 +199,7 @@
                   <key>x</key>
                   <integer>192</integer>
                   <key>y</key>
-                  <string>-13</string>
+                  <integer>-13</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -209,7 +209,7 @@
                   <key>x</key>
                   <integer>286</integer>
                   <key>y</key>
-                  <string>-13</string>
+                  <integer>-13</integer>
                 </dict>
               </array>
             </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/t_ya-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/t_ya-deva.glif
@@ -101,7 +101,7 @@
               <key>x</key>
               <integer>148</integer>
               <key>y</key>
-              <string>-103</string>
+              <integer>-103</integer>
             </dict>
             <dict>
               <key>name</key>
@@ -140,7 +140,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-802</string>
+                  <integer>-802</integer>
                   <key>y</key>
                   <integer>374</integer>
                 </dict>
@@ -148,7 +148,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-767</string>
+                  <integer>-767</integer>
                   <key>y</key>
                   <integer>406</integer>
                 </dict>
@@ -158,7 +158,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-700</string>
+                  <integer>-700</integer>
                   <key>y</key>
                   <integer>406</integer>
                 </dict>
@@ -166,7 +166,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-633</string>
+                  <integer>-633</integer>
                   <key>y</key>
                   <integer>406</integer>
                 </dict>
@@ -174,7 +174,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-620</string>
+                  <integer>-620</integer>
                   <key>y</key>
                   <integer>392</integer>
                 </dict>
@@ -184,7 +184,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-585</string>
+                  <integer>-585</integer>
                   <key>y</key>
                   <integer>322</integer>
                 </dict>
@@ -194,7 +194,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-518</string>
+                  <integer>-518</integer>
                   <key>y</key>
                   <integer>294</integer>
                 </dict>
@@ -202,7 +202,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-577</string>
+                  <integer>-577</integer>
                   <key>y</key>
                   <integer>406</integer>
                 </dict>
@@ -210,7 +210,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-582</string>
+                  <integer>-582</integer>
                   <key>y</key>
                   <integer>450</integer>
                 </dict>
@@ -220,7 +220,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-700</string>
+                  <integer>-700</integer>
                   <key>y</key>
                   <integer>450</integer>
                 </dict>
@@ -228,7 +228,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-805</string>
+                  <integer>-805</integer>
                   <key>y</key>
                   <integer>450</integer>
                 </dict>
@@ -236,7 +236,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-858</string>
+                  <integer>-858</integer>
                   <key>y</key>
                   <integer>393</integer>
                 </dict>
@@ -246,7 +246,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-858</string>
+                  <integer>-858</integer>
                   <key>y</key>
                   <integer>227</integer>
                 </dict>
@@ -254,7 +254,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-858</string>
+                  <integer>-858</integer>
                   <key>y</key>
                   <integer>60</integer>
                 </dict>
@@ -262,7 +262,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-789</string>
+                  <integer>-789</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -272,7 +272,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-680</string>
+                  <integer>-680</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -282,7 +282,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-668</string>
+                  <integer>-668</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -292,7 +292,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-668</string>
+                  <integer>-668</integer>
                   <key>y</key>
                   <integer>44</integer>
                 </dict>
@@ -302,7 +302,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-680</string>
+                  <integer>-680</integer>
                   <key>y</key>
                   <integer>44</integer>
                 </dict>
@@ -310,7 +310,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-756</string>
+                  <integer>-756</integer>
                   <key>y</key>
                   <integer>44</integer>
                 </dict>
@@ -318,7 +318,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-802</string>
+                  <integer>-802</integer>
                   <key>y</key>
                   <integer>80</integer>
                 </dict>
@@ -328,7 +328,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-804</string>
+                  <integer>-804</integer>
                   <key>y</key>
                   <integer>227</integer>
                 </dict>
@@ -343,7 +343,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-930</string>
+                  <integer>-930</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -353,7 +353,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-930</string>
+                  <integer>-930</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -363,7 +363,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-234</string>
+                  <integer>-234</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -373,7 +373,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-234</string>
+                  <integer>-234</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -383,7 +383,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-180</string>
+                  <integer>-180</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -393,17 +393,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-180</string>
-                  <key>y</key>
-                  <integer>590</integer>
-                </dict>
-                <dict>
-                  <key>segmentType</key>
-                  <string>line</string>
-                  <key>smooth</key>
-                  <integer>0</integer>
-                  <key>x</key>
-                  <string>-60</string>
+                  <integer>-180</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -413,7 +403,17 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-60</string>
+                  <integer>-60</integer>
+                  <key>y</key>
+                  <integer>590</integer>
+                </dict>
+                <dict>
+                  <key>segmentType</key>
+                  <string>line</string>
+                  <key>smooth</key>
+                  <integer>0</integer>
+                  <key>x</key>
+                  <integer>-60</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -426,7 +426,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-432</string>
+                  <integer>-432</integer>
                   <key>y</key>
                   <integer>338</integer>
                 </dict>
@@ -434,7 +434,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-396</string>
+                  <integer>-396</integer>
                   <key>y</key>
                   <integer>388</integer>
                 </dict>
@@ -444,7 +444,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-396</string>
+                  <integer>-396</integer>
                   <key>y</key>
                   <integer>464</integer>
                 </dict>
@@ -452,7 +452,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-396</string>
+                  <integer>-396</integer>
                   <key>y</key>
                   <integer>504</integer>
                 </dict>
@@ -460,7 +460,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-412</string>
+                  <integer>-412</integer>
                   <key>y</key>
                   <integer>576</integer>
                 </dict>
@@ -470,7 +470,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-454</string>
+                  <integer>-454</integer>
                   <key>y</key>
                   <integer>629</integer>
                 </dict>
@@ -480,7 +480,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-513</string>
+                  <integer>-513</integer>
                   <key>y</key>
                   <integer>629</integer>
                 </dict>
@@ -488,7 +488,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-471</string>
+                  <integer>-471</integer>
                   <key>y</key>
                   <integer>576</integer>
                 </dict>
@@ -496,7 +496,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-450</string>
+                  <integer>-450</integer>
                   <key>y</key>
                   <integer>516</integer>
                 </dict>
@@ -506,7 +506,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-450</string>
+                  <integer>-450</integer>
                   <key>y</key>
                   <integer>464</integer>
                 </dict>
@@ -514,7 +514,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-450</string>
+                  <integer>-450</integer>
                   <key>y</key>
                   <integer>400</integer>
                 </dict>
@@ -522,7 +522,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-479</string>
+                  <integer>-479</integer>
                   <key>y</key>
                   <integer>362</integer>
                 </dict>
@@ -532,7 +532,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-585</string>
+                  <integer>-585</integer>
                   <key>y</key>
                   <integer>322</integer>
                 </dict>
@@ -540,7 +540,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-534</string>
+                  <integer>-534</integer>
                   <key>y</key>
                   <integer>211</integer>
                 </dict>
@@ -548,7 +548,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-478</string>
+                  <integer>-478</integer>
                   <key>y</key>
                   <integer>177</integer>
                 </dict>
@@ -558,7 +558,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-372</string>
+                  <integer>-372</integer>
                   <key>y</key>
                   <integer>177</integer>
                 </dict>
@@ -566,7 +566,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-332</string>
+                  <integer>-332</integer>
                   <key>y</key>
                   <integer>177</integer>
                 </dict>
@@ -574,7 +574,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-260</string>
+                  <integer>-260</integer>
                   <key>y</key>
                   <integer>190</integer>
                 </dict>
@@ -584,7 +584,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-207</string>
+                  <integer>-207</integer>
                   <key>y</key>
                   <integer>231</integer>
                 </dict>
@@ -594,7 +594,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-207</string>
+                  <integer>-207</integer>
                   <key>y</key>
                   <integer>284</integer>
                 </dict>
@@ -602,7 +602,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-260</string>
+                  <integer>-260</integer>
                   <key>y</key>
                   <integer>242</integer>
                 </dict>
@@ -610,7 +610,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-320</string>
+                  <integer>-320</integer>
                   <key>y</key>
                   <integer>221</integer>
                 </dict>
@@ -620,7 +620,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-372</string>
+                  <integer>-372</integer>
                   <key>y</key>
                   <integer>221</integer>
                 </dict>
@@ -628,7 +628,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-429</string>
+                  <integer>-429</integer>
                   <key>y</key>
                   <integer>221</integer>
                 </dict>
@@ -636,7 +636,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-483</string>
+                  <integer>-483</integer>
                   <key>y</key>
                   <integer>232</integer>
                 </dict>
@@ -646,7 +646,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-518</string>
+                  <integer>-518</integer>
                   <key>y</key>
                   <integer>294</integer>
                 </dict>
@@ -1135,7 +1135,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>674</integer>
                 </dict>
@@ -1145,7 +1145,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>550</integer>
                 </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/ta-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/ta-deva.glif
@@ -57,7 +57,7 @@
               <key>x</key>
               <integer>148</integer>
               <key>y</key>
-              <string>-103</string>
+              <integer>-103</integer>
             </dict>
             <dict>
               <key>name</key>

--- a/Source Files/Biryani-Bold.ufo/glyphs/thorn.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/thorn.glif
@@ -83,7 +83,7 @@
                   <key>x</key>
                   <integer>100</integer>
                   <key>y</key>
-                  <string>-234</string>
+                  <integer>-234</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -93,7 +93,7 @@
                   <key>x</key>
                   <integer>154</integer>
                   <key>y</key>
-                  <string>-234</string>
+                  <integer>-234</integer>
                 </dict>
               </array>
             </dict>
@@ -290,7 +290,7 @@
                   <key>x</key>
                   <integer>247</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -300,7 +300,7 @@
                   <key>x</key>
                   <integer>318</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -308,7 +308,7 @@
                   <key>x</key>
                   <integer>459</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>

--- a/Source Files/Biryani-Bold.ufo/glyphs/three.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/three.glif
@@ -71,7 +71,7 @@
                   <key>x</key>
                   <integer>119</integer>
                   <key>y</key>
-                  <string>-4</string>
+                  <integer>-4</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -79,7 +79,7 @@
                   <key>x</key>
                   <integer>173</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -89,7 +89,7 @@
                   <key>x</key>
                   <integer>240</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -97,7 +97,7 @@
                   <key>x</key>
                   <integer>371</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>

--- a/Source Files/Biryani-Bold.ufo/glyphs/tt_ya-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/tt_ya-deva.glif
@@ -92,7 +92,7 @@
               <key>x</key>
               <integer>268</integer>
               <key>y</key>
-              <string>-80</string>
+              <integer>-80</integer>
             </dict>
             <dict>
               <key>name</key>
@@ -125,7 +125,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -135,7 +135,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/tta-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/tta-deva.glif
@@ -65,7 +65,7 @@
               <key>x</key>
               <integer>268</integer>
               <key>y</key>
-              <string>-80</string>
+              <integer>-80</integer>
             </dict>
             <dict>
               <key>name</key>
@@ -339,7 +339,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -349,7 +349,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/tth_ya-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/tth_ya-deva.glif
@@ -106,7 +106,7 @@
               <key>x</key>
               <integer>288</integer>
               <key>y</key>
-              <string>-80</string>
+              <integer>-80</integer>
             </dict>
             <dict>
               <key>name</key>

--- a/Source Files/Biryani-Bold.ufo/glyphs/ttha-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/ttha-deva.glif
@@ -73,7 +73,7 @@
               <key>x</key>
               <integer>288</integer>
               <key>y</key>
-              <string>-80</string>
+              <integer>-80</integer>
             </dict>
             <dict>
               <key>name</key>

--- a/Source Files/Biryani-Bold.ufo/glyphs/u-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/u-deva.glif
@@ -438,7 +438,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -448,7 +448,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/u.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/u.glif
@@ -73,7 +73,7 @@
                   <key>x</key>
                   <integer>384</integer>
                   <key>y</key>
-                  <string>-12</string>
+                  <integer>-12</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -199,7 +199,7 @@
                   <key>x</key>
                   <integer>183</integer>
                   <key>y</key>
-                  <string>-12</string>
+                  <integer>-12</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -209,7 +209,7 @@
                   <key>x</key>
                   <integer>309</integer>
                   <key>y</key>
-                  <string>-12</string>
+                  <integer>-12</integer>
                 </dict>
               </array>
             </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/uu-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/uu-deva.glif
@@ -101,7 +101,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-773</string>
+                  <integer>-773</integer>
                   <key>y</key>
                   <integer>43</integer>
                 </dict>
@@ -109,7 +109,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-685</string>
+                  <integer>-685</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -119,7 +119,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-569</string>
+                  <integer>-569</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -127,7 +127,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-453</string>
+                  <integer>-453</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -135,7 +135,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-365</string>
+                  <integer>-365</integer>
                   <key>y</key>
                   <integer>43</integer>
                 </dict>
@@ -145,7 +145,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-365</string>
+                  <integer>-365</integer>
                   <key>y</key>
                   <integer>181</integer>
                 </dict>
@@ -153,7 +153,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-365</string>
+                  <integer>-365</integer>
                   <key>y</key>
                   <integer>264</integer>
                 </dict>
@@ -161,7 +161,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-400</string>
+                  <integer>-400</integer>
                   <key>y</key>
                   <integer>334</integer>
                 </dict>
@@ -171,7 +171,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-481</string>
+                  <integer>-481</integer>
                   <key>y</key>
                   <integer>350</integer>
                 </dict>
@@ -181,7 +181,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-481</string>
+                  <integer>-481</integer>
                   <key>y</key>
                   <integer>333</integer>
                 </dict>
@@ -189,7 +189,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-403</string>
+                  <integer>-403</integer>
                   <key>y</key>
                   <integer>363</integer>
                 </dict>
@@ -197,7 +197,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-365</string>
+                  <integer>-365</integer>
                   <key>y</key>
                   <integer>410</integer>
                 </dict>
@@ -207,7 +207,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-365</string>
+                  <integer>-365</integer>
                   <key>y</key>
                   <integer>485</integer>
                 </dict>
@@ -215,7 +215,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-365</string>
+                  <integer>-365</integer>
                   <key>y</key>
                   <integer>572</integer>
                 </dict>
@@ -223,7 +223,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-405</string>
+                  <integer>-405</integer>
                   <key>y</key>
                   <integer>598</integer>
                 </dict>
@@ -233,7 +233,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-453</string>
+                  <integer>-453</integer>
                   <key>y</key>
                   <integer>626</integer>
                 </dict>
@@ -243,7 +243,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-484</string>
+                  <integer>-484</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -251,7 +251,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-438</string>
+                  <integer>-438</integer>
                   <key>y</key>
                   <integer>562</integer>
                 </dict>
@@ -259,7 +259,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-419</string>
+                  <integer>-419</integer>
                   <key>y</key>
                   <integer>540</integer>
                 </dict>
@@ -269,7 +269,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-419</string>
+                  <integer>-419</integer>
                   <key>y</key>
                   <integer>485</integer>
                 </dict>
@@ -277,7 +277,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-419</string>
+                  <integer>-419</integer>
                   <key>y</key>
                   <integer>421</integer>
                 </dict>
@@ -285,7 +285,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-460</string>
+                  <integer>-460</integer>
                   <key>y</key>
                   <integer>365</integer>
                 </dict>
@@ -295,7 +295,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-559</string>
+                  <integer>-559</integer>
                   <key>y</key>
                   <integer>365</integer>
                 </dict>
@@ -305,7 +305,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-631</string>
+                  <integer>-631</integer>
                   <key>y</key>
                   <integer>365</integer>
                 </dict>
@@ -315,7 +315,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-631</string>
+                  <integer>-631</integer>
                   <key>y</key>
                   <integer>321</integer>
                 </dict>
@@ -325,7 +325,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-560</string>
+                  <integer>-560</integer>
                   <key>y</key>
                   <integer>321</integer>
                 </dict>
@@ -333,7 +333,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-460</string>
+                  <integer>-460</integer>
                   <key>y</key>
                   <integer>321</integer>
                 </dict>
@@ -341,7 +341,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-419</string>
+                  <integer>-419</integer>
                   <key>y</key>
                   <integer>273</integer>
                 </dict>
@@ -351,7 +351,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-419</string>
+                  <integer>-419</integer>
                   <key>y</key>
                   <integer>181</integer>
                 </dict>
@@ -359,7 +359,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-419</string>
+                  <integer>-419</integer>
                   <key>y</key>
                   <integer>64</integer>
                 </dict>
@@ -367,7 +367,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-488</string>
+                  <integer>-488</integer>
                   <key>y</key>
                   <integer>44</integer>
                 </dict>
@@ -377,7 +377,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-569</string>
+                  <integer>-569</integer>
                   <key>y</key>
                   <integer>44</integer>
                 </dict>
@@ -385,7 +385,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-650</string>
+                  <integer>-650</integer>
                   <key>y</key>
                   <integer>44</integer>
                 </dict>
@@ -393,7 +393,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-719</string>
+                  <integer>-719</integer>
                   <key>y</key>
                   <integer>64</integer>
                 </dict>
@@ -403,7 +403,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-719</string>
+                  <integer>-719</integer>
                   <key>y</key>
                   <integer>181</integer>
                 </dict>
@@ -413,7 +413,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-719</string>
+                  <integer>-719</integer>
                   <key>y</key>
                   <integer>231</integer>
                 </dict>
@@ -423,7 +423,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-773</string>
+                  <integer>-773</integer>
                   <key>y</key>
                   <integer>231</integer>
                 </dict>
@@ -433,7 +433,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-773</string>
+                  <integer>-773</integer>
                   <key>y</key>
                   <integer>181</integer>
                 </dict>
@@ -446,7 +446,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-82</string>
+                  <integer>-82</integer>
                   <key>y</key>
                   <integer>286</integer>
                 </dict>
@@ -454,7 +454,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-141</string>
+                  <integer>-141</integer>
                   <key>y</key>
                   <integer>321</integer>
                 </dict>
@@ -464,7 +464,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-249</string>
+                  <integer>-249</integer>
                   <key>y</key>
                   <integer>321</integer>
                 </dict>
@@ -472,7 +472,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-309</string>
+                  <integer>-309</integer>
                   <key>y</key>
                   <integer>321</integer>
                 </dict>
@@ -480,7 +480,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-350</string>
+                  <integer>-350</integer>
                   <key>y</key>
                   <integer>302</integer>
                 </dict>
@@ -490,7 +490,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-391</string>
+                  <integer>-391</integer>
                   <key>y</key>
                   <integer>272</integer>
                 </dict>
@@ -500,7 +500,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-391</string>
+                  <integer>-391</integer>
                   <key>y</key>
                   <integer>215</integer>
                 </dict>
@@ -508,7 +508,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-358</string>
+                  <integer>-358</integer>
                   <key>y</key>
                   <integer>244</integer>
                 </dict>
@@ -516,7 +516,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-323</string>
+                  <integer>-323</integer>
                   <key>y</key>
                   <integer>277</integer>
                 </dict>
@@ -526,7 +526,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-249</string>
+                  <integer>-249</integer>
                   <key>y</key>
                   <integer>277</integer>
                 </dict>
@@ -534,7 +534,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-165</string>
+                  <integer>-165</integer>
                   <key>y</key>
                   <integer>277</integer>
                 </dict>
@@ -542,7 +542,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-136</string>
+                  <integer>-136</integer>
                   <key>y</key>
                   <integer>236</integer>
                 </dict>
@@ -552,7 +552,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-136</string>
+                  <integer>-136</integer>
                   <key>y</key>
                   <integer>161</integer>
                 </dict>
@@ -560,7 +560,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-136</string>
+                  <integer>-136</integer>
                   <key>y</key>
                   <integer>67</integer>
                 </dict>
@@ -568,7 +568,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-179</string>
+                  <integer>-179</integer>
                   <key>y</key>
                   <integer>44</integer>
                 </dict>
@@ -578,7 +578,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-249</string>
+                  <integer>-249</integer>
                   <key>y</key>
                   <integer>44</integer>
                 </dict>
@@ -588,7 +588,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-261</string>
+                  <integer>-261</integer>
                   <key>y</key>
                   <integer>44</integer>
                 </dict>
@@ -596,7 +596,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-279</string>
+                  <integer>-279</integer>
                   <key>y</key>
                   <integer>44</integer>
                 </dict>
@@ -604,7 +604,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-303</string>
+                  <integer>-303</integer>
                   <key>y</key>
                   <integer>46</integer>
                 </dict>
@@ -614,7 +614,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-321</string>
+                  <integer>-321</integer>
                   <key>y</key>
                   <integer>50</integer>
                 </dict>
@@ -624,7 +624,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-321</string>
+                  <integer>-321</integer>
                   <key>y</key>
                   <integer>5</integer>
                 </dict>
@@ -632,7 +632,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-310</string>
+                  <integer>-310</integer>
                   <key>y</key>
                   <integer>3</integer>
                 </dict>
@@ -640,7 +640,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-279</string>
+                  <integer>-279</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -650,7 +650,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-261</string>
+                  <integer>-261</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -660,7 +660,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-249</string>
+                  <integer>-249</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -668,7 +668,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-141</string>
+                  <integer>-141</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -676,7 +676,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-82</string>
+                  <integer>-82</integer>
                   <key>y</key>
                   <integer>42</integer>
                 </dict>
@@ -686,7 +686,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-82</string>
+                  <integer>-82</integer>
                   <key>y</key>
                   <integer>161</integer>
                 </dict>
@@ -701,7 +701,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-25</string>
+                  <integer>-25</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -711,7 +711,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-25</string>
+                  <integer>-25</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -721,7 +721,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-851</string>
+                  <integer>-851</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -731,7 +731,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-851</string>
+                  <integer>-851</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -1111,7 +1111,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>674</integer>
                 </dict>
@@ -1121,7 +1121,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>550</integer>
                 </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/va-deva.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/va-deva.glif
@@ -102,7 +102,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -112,7 +112,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/w.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/w.glif
@@ -120,7 +120,7 @@
                   <key>x</key>
                   <integer>264</integer>
                   <key>y</key>
-                  <string>-9</string>
+                  <integer>-9</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -130,7 +130,7 @@
                   <key>x</key>
                   <integer>312</integer>
                   <key>y</key>
-                  <string>-9</string>
+                  <integer>-9</integer>
                 </dict>
               </array>
             </dict>
@@ -205,7 +205,7 @@
                   <key>x</key>
                   <integer>621</integer>
                   <key>y</key>
-                  <string>-9</string>
+                  <integer>-9</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -215,7 +215,7 @@
                   <key>x</key>
                   <integer>669</integer>
                   <key>y</key>
-                  <string>-9</string>
+                  <integer>-9</integer>
                 </dict>
               </array>
             </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/y.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/y.glif
@@ -70,7 +70,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-232</string>
+                  <integer>-232</integer>
                   <key>y</key>
                   <integer>63</integer>
                 </dict>
@@ -80,7 +80,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-427</string>
+                  <integer>-427</integer>
                   <key>y</key>
                   <integer>546</integer>
                 </dict>
@@ -90,7 +90,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-485</string>
+                  <integer>-485</integer>
                   <key>y</key>
                   <integer>546</integer>
                 </dict>
@@ -100,9 +100,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-261</string>
+                  <integer>-261</integer>
                   <key>y</key>
-                  <string>-9</string>
+                  <integer>-9</integer>
                 </dict>
               </array>
             </dict>
@@ -113,17 +113,17 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-336</string>
+                  <integer>-336</integer>
                   <key>y</key>
-                  <string>-171</string>
+                  <integer>-171</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-348</string>
+                  <integer>-348</integer>
                   <key>y</key>
-                  <string>-197</string>
+                  <integer>-197</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -131,25 +131,25 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-393</string>
+                  <integer>-393</integer>
                   <key>y</key>
-                  <string>-197</string>
+                  <integer>-197</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-408</string>
+                  <integer>-408</integer>
                   <key>y</key>
-                  <string>-197</string>
+                  <integer>-197</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-424</string>
+                  <integer>-424</integer>
                   <key>y</key>
-                  <string>-196</string>
+                  <integer>-196</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -157,9 +157,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-439</string>
+                  <integer>-439</integer>
                   <key>y</key>
-                  <string>-193</string>
+                  <integer>-193</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -167,25 +167,25 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-439</string>
+                  <integer>-439</integer>
                   <key>y</key>
-                  <string>-247</string>
+                  <integer>-247</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-424</string>
+                  <integer>-424</integer>
                   <key>y</key>
-                  <string>-250</string>
+                  <integer>-250</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-409</string>
+                  <integer>-409</integer>
                   <key>y</key>
-                  <string>-251</string>
+                  <integer>-251</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -193,25 +193,25 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-398</string>
+                  <integer>-398</integer>
                   <key>y</key>
-                  <string>-251</string>
+                  <integer>-251</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-306</string>
+                  <integer>-306</integer>
                   <key>y</key>
-                  <string>-251</string>
+                  <integer>-251</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-296</string>
+                  <integer>-296</integer>
                   <key>y</key>
-                  <string>-217</string>
+                  <integer>-217</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -219,9 +219,9 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-245</string>
+                  <integer>-245</integer>
                   <key>y</key>
-                  <string>-89</string>
+                  <integer>-89</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -239,7 +239,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-48</string>
+                  <integer>-48</integer>
                   <key>y</key>
                   <integer>546</integer>
                 </dict>
@@ -249,9 +249,9 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-301</string>
+                  <integer>-301</integer>
                   <key>y</key>
-                  <string>-84</string>
+                  <integer>-84</integer>
                 </dict>
               </array>
             </dict>
@@ -296,7 +296,7 @@
                   <key>x</key>
                   <integer>274</integer>
                   <key>y</key>
-                  <string>-9</string>
+                  <integer>-9</integer>
                 </dict>
               </array>
             </dict>
@@ -309,7 +309,7 @@
                   <key>x</key>
                   <integer>200</integer>
                   <key>y</key>
-                  <string>-171</string>
+                  <integer>-171</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -317,7 +317,7 @@
                   <key>x</key>
                   <integer>187</integer>
                   <key>y</key>
-                  <string>-197</string>
+                  <integer>-197</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -327,7 +327,7 @@
                   <key>x</key>
                   <integer>142</integer>
                   <key>y</key>
-                  <string>-197</string>
+                  <integer>-197</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -335,7 +335,7 @@
                   <key>x</key>
                   <integer>127</integer>
                   <key>y</key>
-                  <string>-197</string>
+                  <integer>-197</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -343,7 +343,7 @@
                   <key>x</key>
                   <integer>111</integer>
                   <key>y</key>
-                  <string>-196</string>
+                  <integer>-196</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -353,7 +353,7 @@
                   <key>x</key>
                   <integer>96</integer>
                   <key>y</key>
-                  <string>-193</string>
+                  <integer>-193</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -363,7 +363,7 @@
                   <key>x</key>
                   <integer>96</integer>
                   <key>y</key>
-                  <string>-247</string>
+                  <integer>-247</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -371,7 +371,7 @@
                   <key>x</key>
                   <integer>111</integer>
                   <key>y</key>
-                  <string>-250</string>
+                  <integer>-250</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -379,7 +379,7 @@
                   <key>x</key>
                   <integer>126</integer>
                   <key>y</key>
-                  <string>-251</string>
+                  <integer>-251</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -389,7 +389,7 @@
                   <key>x</key>
                   <integer>137</integer>
                   <key>y</key>
-                  <string>-251</string>
+                  <integer>-251</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -397,7 +397,7 @@
                   <key>x</key>
                   <integer>229</integer>
                   <key>y</key>
-                  <string>-251</string>
+                  <integer>-251</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -405,7 +405,7 @@
                   <key>x</key>
                   <integer>240</integer>
                   <key>y</key>
-                  <string>-217</string>
+                  <integer>-217</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -415,7 +415,7 @@
                   <key>x</key>
                   <integer>290</integer>
                   <key>y</key>
-                  <string>-89</string>
+                  <integer>-89</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -445,7 +445,7 @@
                   <key>x</key>
                   <integer>234</integer>
                   <key>y</key>
-                  <string>-84</string>
+                  <integer>-84</integer>
                 </dict>
               </array>
             </dict>

--- a/Source Files/Biryani-Bold.ufo/glyphs/ya-deva.post.glif
+++ b/Source Files/Biryani-Bold.ufo/glyphs/ya-deva.post.glif
@@ -88,7 +88,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-11</string>
+                  <integer>-11</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -98,7 +98,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-11</string>
+                  <integer>-11</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>

--- a/Source Files/Biryani-Bold.ufo/lib.plist
+++ b/Source Files/Biryani-Bold.ufo/lib.plist
@@ -93,7 +93,7 @@
 			<key>x</key>
 			<integer>388</integer>
 			<key>y</key>
-			<string>-350</string>
+			<integer>-350</integer>
 		</dict>
 	</array>
 	<key>com.typemytype.robofont.italicSlantOffset</key>

--- a/Source Files/Biryani-Light.ufo/glyphs/B_.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/B_.glif
@@ -81,7 +81,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-161</string>
+                  <integer>-161</integer>
                   <key>y</key>
                   <integer>408</integer>
                 </dict>
@@ -89,7 +89,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-122</string>
+                  <integer>-122</integer>
                   <key>y</key>
                   <integer>469</integer>
                 </dict>
@@ -99,7 +99,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-122</string>
+                  <integer>-122</integer>
                   <key>y</key>
                   <integer>555</integer>
                 </dict>
@@ -107,7 +107,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-122</string>
+                  <integer>-122</integer>
                   <key>y</key>
                   <integer>689</integer>
                 </dict>
@@ -115,7 +115,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-176</string>
+                  <integer>-176</integer>
                   <key>y</key>
                   <integer>758</integer>
                 </dict>
@@ -125,7 +125,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-349</string>
+                  <integer>-349</integer>
                   <key>y</key>
                   <integer>758</integer>
                 </dict>
@@ -135,7 +135,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-584</string>
+                  <integer>-584</integer>
                   <key>y</key>
                   <integer>758</integer>
                 </dict>
@@ -145,7 +145,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-584</string>
+                  <integer>-584</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -155,7 +155,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-349</string>
+                  <integer>-349</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -163,7 +163,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-158</string>
+                  <integer>-158</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -171,7 +171,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-92</string>
+                  <integer>-92</integer>
                   <key>y</key>
                   <integer>71</integer>
                 </dict>
@@ -181,7 +181,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-92</string>
+                  <integer>-92</integer>
                   <key>y</key>
                   <integer>202</integer>
                 </dict>
@@ -189,7 +189,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-92</string>
+                  <integer>-92</integer>
                   <key>y</key>
                   <integer>301</integer>
                 </dict>
@@ -197,7 +197,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-143</string>
+                  <integer>-143</integer>
                   <key>y</key>
                   <integer>364</integer>
                 </dict>
@@ -207,7 +207,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-248</string>
+                  <integer>-248</integer>
                   <key>y</key>
                   <integer>391</integer>
                 </dict>
@@ -217,7 +217,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-247</string>
+                  <integer>-247</integer>
                   <key>y</key>
                   <integer>377</integer>
                 </dict>
@@ -232,7 +232,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-349</string>
+                  <integer>-349</integer>
                   <key>y</key>
                   <integer>706</integer>
                 </dict>
@@ -240,7 +240,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-218</string>
+                  <integer>-218</integer>
                   <key>y</key>
                   <integer>706</integer>
                 </dict>
@@ -248,7 +248,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-179</string>
+                  <integer>-179</integer>
                   <key>y</key>
                   <integer>662</integer>
                 </dict>
@@ -258,7 +258,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-180</string>
+                  <integer>-180</integer>
                   <key>y</key>
                   <integer>555</integer>
                 </dict>
@@ -266,7 +266,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-181</string>
+                  <integer>-181</integer>
                   <key>y</key>
                   <integer>454</integer>
                 </dict>
@@ -274,7 +274,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-238</string>
+                  <integer>-238</integer>
                   <key>y</key>
                   <integer>406</integer>
                 </dict>
@@ -284,7 +284,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-349</string>
+                  <integer>-349</integer>
                   <key>y</key>
                   <integer>406</integer>
                 </dict>
@@ -294,7 +294,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-528</string>
+                  <integer>-528</integer>
                   <key>y</key>
                   <integer>406</integer>
                 </dict>
@@ -304,7 +304,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-528</string>
+                  <integer>-528</integer>
                   <key>y</key>
                   <integer>706</integer>
                 </dict>
@@ -317,7 +317,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-151</string>
+                  <integer>-151</integer>
                   <key>y</key>
                   <integer>100</integer>
                 </dict>
@@ -325,7 +325,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-201</string>
+                  <integer>-201</integer>
                   <key>y</key>
                   <integer>52</integer>
                 </dict>
@@ -335,7 +335,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-349</string>
+                  <integer>-349</integer>
                   <key>y</key>
                   <integer>52</integer>
                 </dict>
@@ -345,7 +345,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-528</string>
+                  <integer>-528</integer>
                   <key>y</key>
                   <integer>52</integer>
                 </dict>
@@ -355,7 +355,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-528</string>
+                  <integer>-528</integer>
                   <key>y</key>
                   <integer>354</integer>
                 </dict>
@@ -365,7 +365,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-349</string>
+                  <integer>-349</integer>
                   <key>y</key>
                   <integer>354</integer>
                 </dict>
@@ -373,7 +373,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-220</string>
+                  <integer>-220</integer>
                   <key>y</key>
                   <integer>354</integer>
                 </dict>
@@ -381,7 +381,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-149</string>
+                  <integer>-149</integer>
                   <key>y</key>
                   <integer>310</integer>
                 </dict>
@@ -391,7 +391,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-150</string>
+                  <integer>-150</integer>
                   <key>y</key>
                   <integer>202</integer>
                 </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/E_ng.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/E_ng.glif
@@ -206,7 +206,7 @@
                   <key>x</key>
                   <integer>629</integer>
                   <key>y</key>
-                  <string>-166</string>
+                  <integer>-166</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -214,7 +214,7 @@
                   <key>x</key>
                   <integer>655</integer>
                   <key>y</key>
-                  <string>-132</string>
+                  <integer>-132</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -224,7 +224,7 @@
                   <key>x</key>
                   <integer>655</integer>
                   <key>y</key>
-                  <string>-5</string>
+                  <integer>-5</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -262,7 +262,7 @@
                   <key>x</key>
                   <integer>599</integer>
                   <key>y</key>
-                  <string>-93</string>
+                  <integer>-93</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -270,7 +270,7 @@
                   <key>x</key>
                   <integer>585</integer>
                   <key>y</key>
-                  <string>-112</string>
+                  <integer>-112</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -280,7 +280,7 @@
                   <key>x</key>
                   <integer>536</integer>
                   <key>y</key>
-                  <string>-112</string>
+                  <integer>-112</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -288,7 +288,7 @@
                   <key>x</key>
                   <integer>521</integer>
                   <key>y</key>
-                  <string>-112</string>
+                  <integer>-112</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -296,7 +296,7 @@
                   <key>x</key>
                   <integer>505</integer>
                   <key>y</key>
-                  <string>-111</string>
+                  <integer>-111</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -306,7 +306,7 @@
                   <key>x</key>
                   <integer>490</integer>
                   <key>y</key>
-                  <string>-108</string>
+                  <integer>-108</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -316,7 +316,7 @@
                   <key>x</key>
                   <integer>490</integer>
                   <key>y</key>
-                  <string>-162</string>
+                  <integer>-162</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -324,7 +324,7 @@
                   <key>x</key>
                   <integer>505</integer>
                   <key>y</key>
-                  <string>-165</string>
+                  <integer>-165</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -332,7 +332,7 @@
                   <key>x</key>
                   <integer>520</integer>
                   <key>y</key>
-                  <string>-166</string>
+                  <integer>-166</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -342,7 +342,7 @@
                   <key>x</key>
                   <integer>531</integer>
                   <key>y</key>
-                  <string>-166</string>
+                  <integer>-166</integer>
                 </dict>
               </array>
             </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/L_slash.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/L_slash.glif
@@ -31,7 +31,7 @@
                 <integer>0</integer>
                 <integer>0</integer>
                 <integer>1</integer>
-                <string>-10</string>
+                <integer>-10</integer>
                 <integer>0</integer>
               </array>
             </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/S_.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/S_.glif
@@ -399,7 +399,7 @@
                   <key>x</key>
                   <integer>241</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -409,7 +409,7 @@
                   <key>x</key>
                   <integer>335</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -417,7 +417,7 @@
                   <key>x</key>
                   <integer>485</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>

--- a/Source Files/Biryani-Light.ufo/glyphs/V_.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/V_.glif
@@ -107,7 +107,7 @@
                   <key>x</key>
                   <integer>386</integer>
                   <key>y</key>
-                  <string>-9</string>
+                  <integer>-9</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -117,7 +117,7 @@
                   <key>x</key>
                   <integer>434</integer>
                   <key>y</key>
-                  <string>-9</string>
+                  <integer>-9</integer>
                 </dict>
               </array>
             </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/W_.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/W_.glif
@@ -148,7 +148,7 @@
                   <key>x</key>
                   <integer>346</integer>
                   <key>y</key>
-                  <string>-9</string>
+                  <integer>-9</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -158,7 +158,7 @@
                   <key>x</key>
                   <integer>394</integer>
                   <key>y</key>
-                  <string>-9</string>
+                  <integer>-9</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -188,7 +188,7 @@
                   <key>x</key>
                   <integer>805</integer>
                   <key>y</key>
-                  <string>-9</string>
+                  <integer>-9</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -198,7 +198,7 @@
                   <key>x</key>
                   <integer>853</integer>
                   <key>y</key>
-                  <string>-9</string>
+                  <integer>-9</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>

--- a/Source Files/Biryani-Light.ufo/glyphs/a.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/a.glif
@@ -99,7 +99,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-889</string>
+                  <integer>-889</integer>
                   <key>y</key>
                   <integer>546</integer>
                 </dict>
@@ -109,7 +109,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-889</string>
+                  <integer>-889</integer>
                   <key>y</key>
                   <integer>496</integer>
                 </dict>
@@ -119,7 +119,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-835</string>
+                  <integer>-835</integer>
                   <key>y</key>
                   <integer>496</integer>
                 </dict>
@@ -127,7 +127,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-699</string>
+                  <integer>-699</integer>
                   <key>y</key>
                   <integer>496</integer>
                 </dict>
@@ -135,7 +135,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-691</string>
+                  <integer>-691</integer>
                   <key>y</key>
                   <integer>423</integer>
                 </dict>
@@ -145,7 +145,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-691</string>
+                  <integer>-691</integer>
                   <key>y</key>
                   <integer>303</integer>
                 </dict>
@@ -155,7 +155,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-691</string>
+                  <integer>-691</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -165,7 +165,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-637</string>
+                  <integer>-637</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -175,7 +175,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-637</string>
+                  <integer>-637</integer>
                   <key>y</key>
                   <integer>313</integer>
                 </dict>
@@ -183,7 +183,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-637</string>
+                  <integer>-637</integer>
                   <key>y</key>
                   <integer>445</integer>
                 </dict>
@@ -191,7 +191,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-659</string>
+                  <integer>-659</integer>
                   <key>y</key>
                   <integer>546</integer>
                 </dict>
@@ -201,7 +201,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-820</string>
+                  <integer>-820</integer>
                   <key>y</key>
                   <integer>546</integer>
                 </dict>
@@ -214,7 +214,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-707</string>
+                  <integer>-707</integer>
                   <key>y</key>
                   <integer>344</integer>
                 </dict>
@@ -222,7 +222,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-773</string>
+                  <integer>-773</integer>
                   <key>y</key>
                   <integer>362</integer>
                 </dict>
@@ -232,7 +232,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-825</string>
+                  <integer>-825</integer>
                   <key>y</key>
                   <integer>362</integer>
                 </dict>
@@ -240,7 +240,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-945</string>
+                  <integer>-945</integer>
                   <key>y</key>
                   <integer>362</integer>
                 </dict>
@@ -248,7 +248,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1030</string>
+                  <integer>-1030</integer>
                   <key>y</key>
                   <integer>295</integer>
                 </dict>
@@ -258,7 +258,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1030</string>
+                  <integer>-1030</integer>
                   <key>y</key>
                   <integer>173</integer>
                 </dict>
@@ -266,7 +266,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1030</string>
+                  <integer>-1030</integer>
                   <key>y</key>
                   <integer>55</integer>
                 </dict>
@@ -274,9 +274,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-946</string>
+                  <integer>-946</integer>
                   <key>y</key>
-                  <string>-13</string>
+                  <integer>-13</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -284,23 +284,23 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-855</string>
+                  <integer>-855</integer>
                   <key>y</key>
-                  <string>-13</string>
+                  <integer>-13</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-786</string>
+                  <integer>-786</integer>
                   <key>y</key>
-                  <string>-13</string>
+                  <integer>-13</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-728</string>
+                  <integer>-728</integer>
                   <key>y</key>
                   <integer>16</integer>
                 </dict>
@@ -310,7 +310,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-666</string>
+                  <integer>-666</integer>
                   <key>y</key>
                   <integer>85</integer>
                 </dict>
@@ -320,7 +320,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-667</string>
+                  <integer>-667</integer>
                   <key>y</key>
                   <integer>139</integer>
                 </dict>
@@ -328,7 +328,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-729</string>
+                  <integer>-729</integer>
                   <key>y</key>
                   <integer>70</integer>
                 </dict>
@@ -336,7 +336,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-797</string>
+                  <integer>-797</integer>
                   <key>y</key>
                   <integer>41</integer>
                 </dict>
@@ -346,7 +346,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-855</string>
+                  <integer>-855</integer>
                   <key>y</key>
                   <integer>41</integer>
                 </dict>
@@ -354,7 +354,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-904</string>
+                  <integer>-904</integer>
                   <key>y</key>
                   <integer>41</integer>
                 </dict>
@@ -362,7 +362,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-974</string>
+                  <integer>-974</integer>
                   <key>y</key>
                   <integer>72</integer>
                 </dict>
@@ -372,7 +372,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-974</string>
+                  <integer>-974</integer>
                   <key>y</key>
                   <integer>173</integer>
                 </dict>
@@ -380,7 +380,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-974</string>
+                  <integer>-974</integer>
                   <key>y</key>
                   <integer>280</integer>
                 </dict>
@@ -388,7 +388,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-894</string>
+                  <integer>-894</integer>
                   <key>y</key>
                   <integer>308</integer>
                 </dict>
@@ -398,7 +398,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-825</string>
+                  <integer>-825</integer>
                   <key>y</key>
                   <integer>308</integer>
                 </dict>
@@ -406,7 +406,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-777</string>
+                  <integer>-777</integer>
                   <key>y</key>
                   <integer>308</integer>
                 </dict>
@@ -414,7 +414,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-718</string>
+                  <integer>-718</integer>
                   <key>y</key>
                   <integer>297</integer>
                 </dict>
@@ -424,7 +424,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-670</string>
+                  <integer>-670</integer>
                   <key>y</key>
                   <integer>264</integer>
                 </dict>
@@ -434,7 +434,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-664</string>
+                  <integer>-664</integer>
                   <key>y</key>
                   <integer>312</integer>
                 </dict>
@@ -449,7 +449,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-424</string>
+                  <integer>-424</integer>
                   <key>y</key>
                   <integer>546</integer>
                 </dict>
@@ -459,7 +459,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-424</string>
+                  <integer>-424</integer>
                   <key>y</key>
                   <integer>386</integer>
                 </dict>
@@ -469,7 +469,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-270</string>
+                  <integer>-270</integer>
                   <key>y</key>
                   <integer>386</integer>
                 </dict>
@@ -477,7 +477,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-207</string>
+                  <integer>-207</integer>
                   <key>y</key>
                   <integer>386</integer>
                 </dict>
@@ -485,7 +485,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-196</string>
+                  <integer>-196</integer>
                   <key>y</key>
                   <integer>358</integer>
                 </dict>
@@ -495,7 +495,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-196</string>
+                  <integer>-196</integer>
                   <key>y</key>
                   <integer>313</integer>
                 </dict>
@@ -505,7 +505,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-196</string>
+                  <integer>-196</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -515,7 +515,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2</string>
+                  <integer>-2</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -525,7 +525,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-2</string>
+                  <integer>-2</integer>
                   <key>y</key>
                   <integer>313</integer>
                 </dict>
@@ -533,7 +533,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2</string>
+                  <integer>-2</integer>
                   <key>y</key>
                   <integer>445</integer>
                 </dict>
@@ -541,7 +541,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-32</string>
+                  <integer>-32</integer>
                   <key>y</key>
                   <integer>546</integer>
                 </dict>
@@ -551,7 +551,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-255</string>
+                  <integer>-255</integer>
                   <key>y</key>
                   <integer>546</integer>
                 </dict>
@@ -564,7 +564,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-171</string>
+                  <integer>-171</integer>
                   <key>y</key>
                   <integer>330</integer>
                 </dict>
@@ -572,7 +572,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-236</string>
+                  <integer>-236</integer>
                   <key>y</key>
                   <integer>352</integer>
                 </dict>
@@ -582,7 +582,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-312</string>
+                  <integer>-312</integer>
                   <key>y</key>
                   <integer>352</integer>
                 </dict>
@@ -590,7 +590,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-444</string>
+                  <integer>-444</integer>
                   <key>y</key>
                   <integer>352</integer>
                 </dict>
@@ -598,7 +598,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-525</string>
+                  <integer>-525</integer>
                   <key>y</key>
                   <integer>287</integer>
                 </dict>
@@ -608,7 +608,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-525</string>
+                  <integer>-525</integer>
                   <key>y</key>
                   <integer>168</integer>
                 </dict>
@@ -616,7 +616,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-525</string>
+                  <integer>-525</integer>
                   <key>y</key>
                   <integer>53</integer>
                 </dict>
@@ -624,9 +624,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-446</string>
+                  <integer>-446</integer>
                   <key>y</key>
-                  <string>-13</string>
+                  <integer>-13</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -634,23 +634,23 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-342</string>
+                  <integer>-342</integer>
                   <key>y</key>
-                  <string>-13</string>
+                  <integer>-13</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-247</string>
+                  <integer>-247</integer>
                   <key>y</key>
-                  <string>-13</string>
+                  <integer>-13</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-192</string>
+                  <integer>-192</integer>
                   <key>y</key>
                   <integer>17</integer>
                 </dict>
@@ -660,7 +660,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-121</string>
+                  <integer>-121</integer>
                   <key>y</key>
                   <integer>95</integer>
                 </dict>
@@ -670,7 +670,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-122</string>
+                  <integer>-122</integer>
                   <key>y</key>
                   <integer>224</integer>
                 </dict>
@@ -678,7 +678,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-180</string>
+                  <integer>-180</integer>
                   <key>y</key>
                   <integer>160</integer>
                 </dict>
@@ -686,7 +686,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-231</string>
+                  <integer>-231</integer>
                   <key>y</key>
                   <integer>126</integer>
                 </dict>
@@ -696,7 +696,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-280</string>
+                  <integer>-280</integer>
                   <key>y</key>
                   <integer>126</integer>
                 </dict>
@@ -704,7 +704,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-300</string>
+                  <integer>-300</integer>
                   <key>y</key>
                   <integer>126</integer>
                 </dict>
@@ -712,7 +712,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-329</string>
+                  <integer>-329</integer>
                   <key>y</key>
                   <integer>137</integer>
                 </dict>
@@ -722,7 +722,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-329</string>
+                  <integer>-329</integer>
                   <key>y</key>
                   <integer>173</integer>
                 </dict>
@@ -730,7 +730,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-329</string>
+                  <integer>-329</integer>
                   <key>y</key>
                   <integer>213</integer>
                 </dict>
@@ -738,7 +738,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-293</string>
+                  <integer>-293</integer>
                   <key>y</key>
                   <integer>223</integer>
                 </dict>
@@ -748,7 +748,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-260</string>
+                  <integer>-260</integer>
                   <key>y</key>
                   <integer>223</integer>
                 </dict>
@@ -756,7 +756,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-218</string>
+                  <integer>-218</integer>
                   <key>y</key>
                   <integer>223</integer>
                 </dict>
@@ -764,7 +764,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-169</string>
+                  <integer>-169</integer>
                   <key>y</key>
                   <integer>210</integer>
                 </dict>
@@ -774,7 +774,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-125</string>
+                  <integer>-125</integer>
                   <key>y</key>
                   <integer>179</integer>
                 </dict>
@@ -784,7 +784,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-119</string>
+                  <integer>-119</integer>
                   <key>y</key>
                   <integer>292</integer>
                 </dict>
@@ -976,7 +976,7 @@
                   <key>x</key>
                   <integer>184</integer>
                   <key>y</key>
-                  <string>-13</string>
+                  <integer>-13</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -986,7 +986,7 @@
                   <key>x</key>
                   <integer>275</integer>
                   <key>y</key>
-                  <string>-13</string>
+                  <integer>-13</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -994,7 +994,7 @@
                   <key>x</key>
                   <integer>344</integer>
                   <key>y</key>
-                  <string>-13</string>
+                  <integer>-13</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>

--- a/Source Files/Biryani-Light.ufo/glyphs/ae.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/ae.glif
@@ -283,7 +283,7 @@
                   <key>x</key>
                   <integer>119</integer>
                   <key>y</key>
-                  <string>-13</string>
+                  <integer>-13</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -293,7 +293,7 @@
                   <key>x</key>
                   <integer>210</integer>
                   <key>y</key>
-                  <string>-13</string>
+                  <integer>-13</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -301,7 +301,7 @@
                   <key>x</key>
                   <integer>291</integer>
                   <key>y</key>
-                  <string>-13</string>
+                  <integer>-13</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -624,7 +624,7 @@
                   <key>x</key>
                   <integer>463</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -634,7 +634,7 @@
                   <key>x</key>
                   <integer>632</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -642,7 +642,7 @@
                   <key>x</key>
                   <integer>695</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -650,7 +650,7 @@
                   <key>x</key>
                   <integer>758</integer>
                   <key>y</key>
-                  <string>-1</string>
+                  <integer>-1</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>

--- a/Source Files/Biryani-Light.ufo/glyphs/aiM_atra-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/aiM_atra-deva.glif
@@ -50,7 +50,7 @@
               <key>name</key>
               <string>top</string>
               <key>x</key>
-              <string>-37</string>
+              <integer>-37</integer>
               <key>y</key>
               <integer>634</integer>
             </dict>
@@ -58,7 +58,7 @@
               <key>name</key>
               <string>_top</string>
               <key>x</key>
-              <string>-138</string>
+              <integer>-138</integer>
               <key>y</key>
               <integer>634</integer>
             </dict>
@@ -77,7 +77,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-109</string>
+                  <integer>-109</integer>
                   <key>y</key>
                   <integer>624</integer>
                 </dict>
@@ -87,7 +87,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-160</string>
+                  <integer>-160</integer>
                   <key>y</key>
                   <integer>850</integer>
                 </dict>
@@ -95,7 +95,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-186</string>
+                  <integer>-186</integer>
                   <key>y</key>
                   <integer>965</integer>
                 </dict>
@@ -103,7 +103,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-235</string>
+                  <integer>-235</integer>
                   <key>y</key>
                   <integer>984</integer>
                 </dict>
@@ -113,7 +113,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-335</string>
+                  <integer>-335</integer>
                   <key>y</key>
                   <integer>984</integer>
                 </dict>
@@ -123,7 +123,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-410</string>
+                  <integer>-410</integer>
                   <key>y</key>
                   <integer>984</integer>
                 </dict>
@@ -133,7 +133,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-410</string>
+                  <integer>-410</integer>
                   <key>y</key>
                   <integer>940</integer>
                 </dict>
@@ -143,7 +143,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-335</string>
+                  <integer>-335</integer>
                   <key>y</key>
                   <integer>940</integer>
                 </dict>
@@ -151,7 +151,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-263</string>
+                  <integer>-263</integer>
                   <key>y</key>
                   <integer>940</integer>
                 </dict>
@@ -159,7 +159,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-230</string>
+                  <integer>-230</integer>
                   <key>y</key>
                   <integer>922</integer>
                 </dict>
@@ -169,7 +169,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-214</string>
+                  <integer>-214</integer>
                   <key>y</key>
                   <integer>850</integer>
                 </dict>
@@ -179,7 +179,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-163</string>
+                  <integer>-163</integer>
                   <key>y</key>
                   <integer>624</integer>
                 </dict>
@@ -194,7 +194,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-116</string>
+                  <integer>-116</integer>
                   <key>y</key>
                   <integer>624</integer>
                 </dict>
@@ -204,7 +204,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-171</string>
+                  <integer>-171</integer>
                   <key>y</key>
                   <integer>699</integer>
                 </dict>
@@ -212,7 +212,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-247</string>
+                  <integer>-247</integer>
                   <key>y</key>
                   <integer>802</integer>
                 </dict>
@@ -220,7 +220,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-274</string>
+                  <integer>-274</integer>
                   <key>y</key>
                   <integer>834</integer>
                 </dict>
@@ -230,7 +230,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-415</string>
+                  <integer>-415</integer>
                   <key>y</key>
                   <integer>834</integer>
                 </dict>
@@ -240,7 +240,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-500</string>
+                  <integer>-500</integer>
                   <key>y</key>
                   <integer>834</integer>
                 </dict>
@@ -250,7 +250,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-500</string>
+                  <integer>-500</integer>
                   <key>y</key>
                   <integer>790</integer>
                 </dict>
@@ -260,7 +260,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-415</string>
+                  <integer>-415</integer>
                   <key>y</key>
                   <integer>790</integer>
                 </dict>
@@ -268,7 +268,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-308</string>
+                  <integer>-308</integer>
                   <key>y</key>
                   <integer>790</integer>
                 </dict>
@@ -276,7 +276,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-272</string>
+                  <integer>-272</integer>
                   <key>y</key>
                   <integer>761</integer>
                 </dict>
@@ -286,7 +286,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-223</string>
+                  <integer>-223</integer>
                   <key>y</key>
                   <integer>699</integer>
                 </dict>
@@ -296,7 +296,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-163</string>
+                  <integer>-163</integer>
                   <key>y</key>
                   <integer>624</integer>
                 </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/at.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/at.glif
@@ -149,7 +149,7 @@
                   <key>x</key>
                   <integer>67</integer>
                   <key>y</key>
-                  <string>-54</string>
+                  <integer>-54</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -157,7 +157,7 @@
                   <key>x</key>
                   <integer>241</integer>
                   <key>y</key>
-                  <string>-212</string>
+                  <integer>-212</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -167,7 +167,7 @@
                   <key>x</key>
                   <integer>486</integer>
                   <key>y</key>
-                  <string>-212</string>
+                  <integer>-212</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -175,7 +175,7 @@
                   <key>x</key>
                   <integer>600</integer>
                   <key>y</key>
-                  <string>-212</string>
+                  <integer>-212</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -183,7 +183,7 @@
                   <key>x</key>
                   <integer>683</integer>
                   <key>y</key>
-                  <string>-179</string>
+                  <integer>-179</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -193,7 +193,7 @@
                   <key>x</key>
                   <integer>768</integer>
                   <key>y</key>
-                  <string>-137</string>
+                  <integer>-137</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -203,7 +203,7 @@
                   <key>x</key>
                   <integer>748</integer>
                   <key>y</key>
-                  <string>-87</string>
+                  <integer>-87</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -211,7 +211,7 @@
                   <key>x</key>
                   <integer>665</integer>
                   <key>y</key>
-                  <string>-130</string>
+                  <integer>-130</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -219,7 +219,7 @@
                   <key>x</key>
                   <integer>584</integer>
                   <key>y</key>
-                  <string>-160</string>
+                  <integer>-160</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -229,7 +229,7 @@
                   <key>x</key>
                   <integer>486</integer>
                   <key>y</key>
-                  <string>-160</string>
+                  <integer>-160</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -237,7 +237,7 @@
                   <key>x</key>
                   <integer>240</integer>
                   <key>y</key>
-                  <string>-160</string>
+                  <integer>-160</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>

--- a/Source Files/Biryani-Light.ufo/glyphs/b.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/b.glif
@@ -298,7 +298,7 @@
                   <key>x</key>
                   <integer>290</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -308,7 +308,7 @@
                   <key>x</key>
                   <integer>361</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -316,7 +316,7 @@
                   <key>x</key>
                   <integer>502</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>

--- a/Source Files/Biryani-Light.ufo/glyphs/bar.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/bar.glif
@@ -45,7 +45,7 @@
                   <key>x</key>
                   <integer>140</integer>
                   <key>y</key>
-                  <string>-129</string>
+                  <integer>-129</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -55,7 +55,7 @@
                   <key>x</key>
                   <integer>196</integer>
                   <key>y</key>
-                  <string>-129</string>
+                  <integer>-129</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>

--- a/Source Files/Biryani-Light.ufo/glyphs/braceleft.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/braceleft.glif
@@ -79,7 +79,7 @@
                   <key>x</key>
                   <integer>346</integer>
                   <key>y</key>
-                  <string>-129</string>
+                  <integer>-129</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -87,7 +87,7 @@
                   <key>x</key>
                   <integer>361</integer>
                   <key>y</key>
-                  <string>-128</string>
+                  <integer>-128</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -97,7 +97,7 @@
                   <key>x</key>
                   <integer>376</integer>
                   <key>y</key>
-                  <string>-125</string>
+                  <integer>-125</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -107,7 +107,7 @@
                   <key>x</key>
                   <integer>376</integer>
                   <key>y</key>
-                  <string>-71</string>
+                  <integer>-71</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -115,7 +115,7 @@
                   <key>x</key>
                   <integer>361</integer>
                   <key>y</key>
-                  <string>-74</string>
+                  <integer>-74</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -123,7 +123,7 @@
                   <key>x</key>
                   <integer>345</integer>
                   <key>y</key>
-                  <string>-75</string>
+                  <integer>-75</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -133,7 +133,7 @@
                   <key>x</key>
                   <integer>330</integer>
                   <key>y</key>
-                  <string>-75</string>
+                  <integer>-75</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -141,7 +141,7 @@
                   <key>x</key>
                   <integer>280</integer>
                   <key>y</key>
-                  <string>-75</string>
+                  <integer>-75</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -149,7 +149,7 @@
                   <key>x</key>
                   <integer>266</integer>
                   <key>y</key>
-                  <string>-59</string>
+                  <integer>-59</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -159,7 +159,7 @@
                   <key>x</key>
                   <integer>266</integer>
                   <key>y</key>
-                  <string>-2</string>
+                  <integer>-2</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -261,7 +261,7 @@
                   <key>x</key>
                   <integer>210</integer>
                   <key>y</key>
-                  <string>-8</string>
+                  <integer>-8</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -269,7 +269,7 @@
                   <key>x</key>
                   <integer>210</integer>
                   <key>y</key>
-                  <string>-103</string>
+                  <integer>-103</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -277,7 +277,7 @@
                   <key>x</key>
                   <integer>246</integer>
                   <key>y</key>
-                  <string>-129</string>
+                  <integer>-129</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -287,7 +287,7 @@
                   <key>x</key>
                   <integer>335</integer>
                   <key>y</key>
-                  <string>-129</string>
+                  <integer>-129</integer>
                 </dict>
               </array>
             </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/c.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/c.glif
@@ -85,7 +85,7 @@
                   <key>x</key>
                   <integer>156</integer>
                   <key>y</key>
-                  <string>-16</string>
+                  <integer>-16</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -95,7 +95,7 @@
                   <key>x</key>
                   <integer>325</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -103,7 +103,7 @@
                   <key>x</key>
                   <integer>388</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -111,7 +111,7 @@
                   <key>x</key>
                   <integer>450</integer>
                   <key>y</key>
-                  <string>-1</string>
+                  <integer>-1</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>

--- a/Source Files/Biryani-Light.ufo/glyphs/c_ca-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/c_ca-deva.glif
@@ -324,7 +324,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-40</string>
+                  <integer>-40</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -334,7 +334,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-40</string>
+                  <integer>-40</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -630,7 +630,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-6</string>
+                  <integer>-6</integer>
                   <key>y</key>
                   <integer>440</integer>
                 </dict>
@@ -640,7 +640,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-6</string>
+                  <integer>-6</integer>
                   <key>y</key>
                   <integer>396</integer>
                 </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/cedilla.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/cedilla.glif
@@ -72,7 +72,7 @@
                   <key>x</key>
                   <integer>370</integer>
                   <key>y</key>
-                  <string>-263</string>
+                  <integer>-263</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -80,7 +80,7 @@
                   <key>x</key>
                   <integer>412</integer>
                   <key>y</key>
-                  <string>-222</string>
+                  <integer>-222</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -90,7 +90,7 @@
                   <key>x</key>
                   <integer>412</integer>
                   <key>y</key>
-                  <string>-165</string>
+                  <integer>-165</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -98,7 +98,7 @@
                   <key>x</key>
                   <integer>412</integer>
                   <key>y</key>
-                  <string>-111</string>
+                  <integer>-111</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -106,7 +106,7 @@
                   <key>x</key>
                   <integer>375</integer>
                   <key>y</key>
-                  <string>-72</string>
+                  <integer>-72</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -116,7 +116,7 @@
                   <key>x</key>
                   <integer>303</integer>
                   <key>y</key>
-                  <string>-72</string>
+                  <integer>-72</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -124,7 +124,7 @@
                   <key>x</key>
                   <integer>281</integer>
                   <key>y</key>
-                  <string>-72</string>
+                  <integer>-72</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -132,7 +132,7 @@
                   <key>x</key>
                   <integer>261</integer>
                   <key>y</key>
-                  <string>-81</string>
+                  <integer>-81</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -142,7 +142,7 @@
                   <key>x</key>
                   <integer>243</integer>
                   <key>y</key>
-                  <string>-90</string>
+                  <integer>-90</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -152,7 +152,7 @@
                   <key>x</key>
                   <integer>218</integer>
                   <key>y</key>
-                  <string>-136</string>
+                  <integer>-136</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -160,7 +160,7 @@
                   <key>x</key>
                   <integer>245</integer>
                   <key>y</key>
-                  <string>-127</string>
+                  <integer>-127</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -168,7 +168,7 @@
                   <key>x</key>
                   <integer>273</integer>
                   <key>y</key>
-                  <string>-119</string>
+                  <integer>-119</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -178,7 +178,7 @@
                   <key>x</key>
                   <integer>303</integer>
                   <key>y</key>
-                  <string>-119</string>
+                  <integer>-119</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -186,7 +186,7 @@
                   <key>x</key>
                   <integer>346</integer>
                   <key>y</key>
-                  <string>-119</string>
+                  <integer>-119</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -194,7 +194,7 @@
                   <key>x</key>
                   <integer>361</integer>
                   <key>y</key>
-                  <string>-139</string>
+                  <integer>-139</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -204,7 +204,7 @@
                   <key>x</key>
                   <integer>361</integer>
                   <key>y</key>
-                  <string>-165</string>
+                  <integer>-165</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -212,7 +212,7 @@
                   <key>x</key>
                   <integer>361</integer>
                   <key>y</key>
-                  <string>-189</string>
+                  <integer>-189</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -220,7 +220,7 @@
                   <key>x</key>
                   <integer>342</integer>
                   <key>y</key>
-                  <string>-216</string>
+                  <integer>-216</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -230,7 +230,7 @@
                   <key>x</key>
                   <integer>290</integer>
                   <key>y</key>
-                  <string>-216</string>
+                  <integer>-216</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -238,7 +238,7 @@
                   <key>x</key>
                   <integer>260</integer>
                   <key>y</key>
-                  <string>-216</string>
+                  <integer>-216</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -246,7 +246,7 @@
                   <key>x</key>
                   <integer>231</integer>
                   <key>y</key>
-                  <string>-210</string>
+                  <integer>-210</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -256,7 +256,7 @@
                   <key>x</key>
                   <integer>198</integer>
                   <key>y</key>
-                  <string>-195</string>
+                  <integer>-195</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -266,7 +266,7 @@
                   <key>x</key>
                   <integer>198</integer>
                   <key>y</key>
-                  <string>-243</string>
+                  <integer>-243</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -274,7 +274,7 @@
                   <key>x</key>
                   <integer>231</integer>
                   <key>y</key>
-                  <string>-258</string>
+                  <integer>-258</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -282,7 +282,7 @@
                   <key>x</key>
                   <integer>260</integer>
                   <key>y</key>
-                  <string>-263</string>
+                  <integer>-263</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -292,7 +292,7 @@
                   <key>x</key>
                   <integer>290</integer>
                   <key>y</key>
-                  <string>-263</string>
+                  <integer>-263</integer>
                 </dict>
               </array>
             </dict>
@@ -317,7 +317,7 @@
                   <key>x</key>
                   <integer>218</integer>
                   <key>y</key>
-                  <string>-136</string>
+                  <integer>-136</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -327,7 +327,7 @@
                   <key>x</key>
                   <integer>278</integer>
                   <key>y</key>
-                  <string>-106</string>
+                  <integer>-106</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>

--- a/Source Files/Biryani-Light.ufo/glyphs/cent.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/cent.glif
@@ -59,7 +59,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-471</string>
+                  <integer>-471</integer>
                   <key>y</key>
                   <integer>102</integer>
                 </dict>
@@ -67,9 +67,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-382</string>
+                  <integer>-382</integer>
                   <key>y</key>
-                  <string>-16</string>
+                  <integer>-16</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -77,25 +77,25 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-213</string>
+                  <integer>-213</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-150</string>
+                  <integer>-150</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-88</string>
+                  <integer>-88</integer>
                   <key>y</key>
-                  <string>-1</string>
+                  <integer>-1</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -103,7 +103,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-30</string>
+                  <integer>-30</integer>
                   <key>y</key>
                   <integer>28</integer>
                 </dict>
@@ -113,7 +113,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-50</string>
+                  <integer>-50</integer>
                   <key>y</key>
                   <integer>78</integer>
                 </dict>
@@ -121,7 +121,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-103</string>
+                  <integer>-103</integer>
                   <key>y</key>
                   <integer>54</integer>
                 </dict>
@@ -129,7 +129,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-158</string>
+                  <integer>-158</integer>
                   <key>y</key>
                   <integer>37</integer>
                 </dict>
@@ -139,7 +139,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-213</string>
+                  <integer>-213</integer>
                   <key>y</key>
                   <integer>37</integer>
                 </dict>
@@ -147,7 +147,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-362</string>
+                  <integer>-362</integer>
                   <key>y</key>
                   <integer>38</integer>
                 </dict>
@@ -155,7 +155,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-415</string>
+                  <integer>-415</integer>
                   <key>y</key>
                   <integer>144</integer>
                 </dict>
@@ -165,7 +165,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-415</string>
+                  <integer>-415</integer>
                   <key>y</key>
                   <integer>275</integer>
                 </dict>
@@ -173,7 +173,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-415</string>
+                  <integer>-415</integer>
                   <key>y</key>
                   <integer>403</integer>
                 </dict>
@@ -181,7 +181,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-362</string>
+                  <integer>-362</integer>
                   <key>y</key>
                   <integer>507</integer>
                 </dict>
@@ -191,7 +191,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-213</string>
+                  <integer>-213</integer>
                   <key>y</key>
                   <integer>508</integer>
                 </dict>
@@ -199,7 +199,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-164</string>
+                  <integer>-164</integer>
                   <key>y</key>
                   <integer>508</integer>
                 </dict>
@@ -207,7 +207,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-124</string>
+                  <integer>-124</integer>
                   <key>y</key>
                   <integer>501</integer>
                 </dict>
@@ -217,7 +217,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-74</string>
+                  <integer>-74</integer>
                   <key>y</key>
                   <integer>477</integer>
                 </dict>
@@ -227,7 +227,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-74</string>
+                  <integer>-74</integer>
                   <key>y</key>
                   <integer>535</integer>
                 </dict>
@@ -235,7 +235,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-119</string>
+                  <integer>-119</integer>
                   <key>y</key>
                   <integer>553</integer>
                 </dict>
@@ -243,7 +243,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-155</string>
+                  <integer>-155</integer>
                   <key>y</key>
                   <integer>562</integer>
                 </dict>
@@ -253,7 +253,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-213</string>
+                  <integer>-213</integer>
                   <key>y</key>
                   <integer>562</integer>
                 </dict>
@@ -261,7 +261,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-382</string>
+                  <integer>-382</integer>
                   <key>y</key>
                   <integer>561</integer>
                 </dict>
@@ -269,7 +269,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-471</string>
+                  <integer>-471</integer>
                   <key>y</key>
                   <integer>444</integer>
                 </dict>
@@ -279,7 +279,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-471</string>
+                  <integer>-471</integer>
                   <key>y</key>
                   <integer>274</integer>
                 </dict>
@@ -294,9 +294,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-242</string>
+                  <integer>-242</integer>
                   <key>y</key>
-                  <string>-96</string>
+                  <integer>-96</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -304,9 +304,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-186</string>
+                  <integer>-186</integer>
                   <key>y</key>
-                  <string>-96</string>
+                  <integer>-96</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -314,7 +314,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-186</string>
+                  <integer>-186</integer>
                   <key>y</key>
                   <integer>641</integer>
                 </dict>
@@ -324,7 +324,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-242</string>
+                  <integer>-242</integer>
                   <key>y</key>
                   <integer>641</integer>
                 </dict>
@@ -347,7 +347,7 @@
                   <key>x</key>
                   <integer>168</integer>
                   <key>y</key>
-                  <string>-16</string>
+                  <integer>-16</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -357,7 +357,7 @@
                   <key>x</key>
                   <integer>337</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -365,7 +365,7 @@
                   <key>x</key>
                   <integer>400</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -373,7 +373,7 @@
                   <key>x</key>
                   <integer>462</integer>
                   <key>y</key>
-                  <string>-1</string>
+                  <integer>-1</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -574,7 +574,7 @@
                   <key>x</key>
                   <integer>308</integer>
                   <key>y</key>
-                  <string>-96</string>
+                  <integer>-96</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -584,7 +584,7 @@
                   <key>x</key>
                   <integer>364</integer>
                   <key>y</key>
-                  <string>-96</string>
+                  <integer>-96</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>

--- a/Source Files/Biryani-Light.ufo/glyphs/ch_na-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/ch_na-deva.glif
@@ -118,7 +118,7 @@
               <key>x</key>
               <integer>400</integer>
               <key>y</key>
-              <string>-229</string>
+              <integer>-229</integer>
             </dict>
             <dict>
               <key>name</key>
@@ -126,7 +126,7 @@
               <key>x</key>
               <integer>565</integer>
               <key>y</key>
-              <string>-237</string>
+              <integer>-237</integer>
             </dict>
             <dict>
               <key>name</key>
@@ -516,7 +516,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -526,7 +526,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -767,7 +767,7 @@
                   <key>x</key>
                   <integer>538</integer>
                   <key>y</key>
-                  <string>-237</string>
+                  <integer>-237</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -777,7 +777,7 @@
                   <key>x</key>
                   <integer>592</integer>
                   <key>y</key>
-                  <string>-237</string>
+                  <integer>-237</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -802,7 +802,7 @@
                   <key>x</key>
                   <integer>581</integer>
                   <key>y</key>
-                  <string>-29</string>
+                  <integer>-29</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -838,7 +838,7 @@
                   <key>x</key>
                   <integer>213</integer>
                   <key>y</key>
-                  <string>-5</string>
+                  <integer>-5</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -848,7 +848,7 @@
                   <key>x</key>
                   <integer>213</integer>
                   <key>y</key>
-                  <string>-49</string>
+                  <integer>-49</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -856,7 +856,7 @@
                   <key>x</key>
                   <integer>213</integer>
                   <key>y</key>
-                  <string>-92</string>
+                  <integer>-92</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -864,7 +864,7 @@
                   <key>x</key>
                   <integer>243</integer>
                   <key>y</key>
-                  <string>-124</string>
+                  <integer>-124</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -874,7 +874,7 @@
                   <key>x</key>
                   <integer>297</integer>
                   <key>y</key>
-                  <string>-148</string>
+                  <integer>-148</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -884,7 +884,7 @@
                   <key>x</key>
                   <integer>318</integer>
                   <key>y</key>
-                  <string>-106</string>
+                  <integer>-106</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -892,7 +892,7 @@
                   <key>x</key>
                   <integer>289</integer>
                   <key>y</key>
-                  <string>-91</string>
+                  <integer>-91</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -900,7 +900,7 @@
                   <key>x</key>
                   <integer>267</integer>
                   <key>y</key>
-                  <string>-74</string>
+                  <integer>-74</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -910,7 +910,7 @@
                   <key>x</key>
                   <integer>267</integer>
                   <key>y</key>
-                  <string>-54</string>
+                  <integer>-54</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -918,7 +918,7 @@
                   <key>x</key>
                   <integer>267</integer>
                   <key>y</key>
-                  <string>-34</string>
+                  <integer>-34</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -926,7 +926,7 @@
                   <key>x</key>
                   <integer>279</integer>
                   <key>y</key>
-                  <string>-29</string>
+                  <integer>-29</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -936,7 +936,7 @@
                   <key>x</key>
                   <integer>308</integer>
                   <key>y</key>
-                  <string>-29</string>
+                  <integer>-29</integer>
                 </dict>
               </array>
             </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/commaaccent.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/commaaccent.glif
@@ -52,9 +52,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-338</string>
+                  <integer>-338</integer>
                   <key>y</key>
-                  <string>-80</string>
+                  <integer>-80</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -62,9 +62,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-370</string>
+                  <integer>-370</integer>
                   <key>y</key>
-                  <string>-246</string>
+                  <integer>-246</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -72,9 +72,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-316</string>
+                  <integer>-316</integer>
                   <key>y</key>
-                  <string>-246</string>
+                  <integer>-246</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -82,9 +82,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-278</string>
+                  <integer>-278</integer>
                   <key>y</key>
-                  <string>-80</string>
+                  <integer>-80</integer>
                 </dict>
               </array>
             </dict>
@@ -99,7 +99,7 @@
                   <key>x</key>
                   <integer>311</integer>
                   <key>y</key>
-                  <string>-80</string>
+                  <integer>-80</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -109,7 +109,7 @@
                   <key>x</key>
                   <integer>279</integer>
                   <key>y</key>
-                  <string>-246</string>
+                  <integer>-246</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -119,7 +119,7 @@
                   <key>x</key>
                   <integer>333</integer>
                   <key>y</key>
-                  <string>-246</string>
+                  <integer>-246</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -129,7 +129,7 @@
                   <key>x</key>
                   <integer>371</integer>
                   <key>y</key>
-                  <string>-80</string>
+                  <integer>-80</integer>
                 </dict>
               </array>
             </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/d.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/d.glif
@@ -96,7 +96,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-799</string>
+                  <integer>-799</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -106,7 +106,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-745</string>
+                  <integer>-745</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -116,7 +116,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-745</string>
+                  <integer>-745</integer>
                   <key>y</key>
                   <integer>846</integer>
                 </dict>
@@ -126,7 +126,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-799</string>
+                  <integer>-799</integer>
                   <key>y</key>
                   <integer>846</integer>
                 </dict>
@@ -139,7 +139,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1201</string>
+                  <integer>-1201</integer>
                   <key>y</key>
                   <integer>78</integer>
                 </dict>
@@ -147,9 +147,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1104</string>
+                  <integer>-1104</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -157,23 +157,23 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-963</string>
+                  <integer>-963</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-892</string>
+                  <integer>-892</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-821</string>
+                  <integer>-821</integer>
                   <key>y</key>
                   <integer>30</integer>
                 </dict>
@@ -183,7 +183,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-771</string>
+                  <integer>-771</integer>
                   <key>y</key>
                   <integer>85</integer>
                 </dict>
@@ -193,7 +193,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-771</string>
+                  <integer>-771</integer>
                   <key>y</key>
                   <integer>139</integer>
                 </dict>
@@ -201,7 +201,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-822</string>
+                  <integer>-822</integer>
                   <key>y</key>
                   <integer>83</integer>
                 </dict>
@@ -209,7 +209,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-888</string>
+                  <integer>-888</integer>
                   <key>y</key>
                   <integer>37</integer>
                 </dict>
@@ -219,7 +219,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-963</string>
+                  <integer>-963</integer>
                   <key>y</key>
                   <integer>37</integer>
                 </dict>
@@ -227,7 +227,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1083</string>
+                  <integer>-1083</integer>
                   <key>y</key>
                   <integer>37</integer>
                 </dict>
@@ -235,7 +235,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1145</string>
+                  <integer>-1145</integer>
                   <key>y</key>
                   <integer>119</integer>
                 </dict>
@@ -245,7 +245,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1145</string>
+                  <integer>-1145</integer>
                   <key>y</key>
                   <integer>273</integer>
                 </dict>
@@ -253,7 +253,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1145</string>
+                  <integer>-1145</integer>
                   <key>y</key>
                   <integer>426</integer>
                 </dict>
@@ -261,7 +261,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1083</string>
+                  <integer>-1083</integer>
                   <key>y</key>
                   <integer>508</integer>
                 </dict>
@@ -271,7 +271,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-963</string>
+                  <integer>-963</integer>
                   <key>y</key>
                   <integer>508</integer>
                 </dict>
@@ -279,7 +279,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-888</string>
+                  <integer>-888</integer>
                   <key>y</key>
                   <integer>508</integer>
                 </dict>
@@ -287,7 +287,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-822</string>
+                  <integer>-822</integer>
                   <key>y</key>
                   <integer>462</integer>
                 </dict>
@@ -297,7 +297,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-771</string>
+                  <integer>-771</integer>
                   <key>y</key>
                   <integer>406</integer>
                 </dict>
@@ -307,7 +307,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-771</string>
+                  <integer>-771</integer>
                   <key>y</key>
                   <integer>460</integer>
                 </dict>
@@ -315,7 +315,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-821</string>
+                  <integer>-821</integer>
                   <key>y</key>
                   <integer>515</integer>
                 </dict>
@@ -323,7 +323,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-892</string>
+                  <integer>-892</integer>
                   <key>y</key>
                   <integer>562</integer>
                 </dict>
@@ -333,7 +333,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-963</string>
+                  <integer>-963</integer>
                   <key>y</key>
                   <integer>562</integer>
                 </dict>
@@ -341,7 +341,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1104</string>
+                  <integer>-1104</integer>
                   <key>y</key>
                   <integer>562</integer>
                 </dict>
@@ -349,7 +349,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1201</string>
+                  <integer>-1201</integer>
                   <key>y</key>
                   <integer>467</integer>
                 </dict>
@@ -359,7 +359,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1201</string>
+                  <integer>-1201</integer>
                   <key>y</key>
                   <integer>273</integer>
                 </dict>
@@ -374,7 +374,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-226</string>
+                  <integer>-226</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -384,7 +384,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-22</string>
+                  <integer>-22</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -394,7 +394,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-22</string>
+                  <integer>-22</integer>
                   <key>y</key>
                   <integer>846</integer>
                 </dict>
@@ -404,7 +404,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-226</string>
+                  <integer>-226</integer>
                   <key>y</key>
                   <integer>846</integer>
                 </dict>
@@ -417,7 +417,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-618</string>
+                  <integer>-618</integer>
                   <key>y</key>
                   <integer>79</integer>
                 </dict>
@@ -425,9 +425,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-511</string>
+                  <integer>-511</integer>
                   <key>y</key>
-                  <string>-16</string>
+                  <integer>-16</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -435,23 +435,23 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-368</string>
+                  <integer>-368</integer>
                   <key>y</key>
-                  <string>-16</string>
+                  <integer>-16</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-284</string>
+                  <integer>-284</integer>
                   <key>y</key>
-                  <string>-16</string>
+                  <integer>-16</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-219</string>
+                  <integer>-219</integer>
                   <key>y</key>
                   <integer>28</integer>
                 </dict>
@@ -461,7 +461,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-168</string>
+                  <integer>-168</integer>
                   <key>y</key>
                   <integer>85</integer>
                 </dict>
@@ -471,7 +471,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-168</string>
+                  <integer>-168</integer>
                   <key>y</key>
                   <integer>244</integer>
                 </dict>
@@ -479,7 +479,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-214</string>
+                  <integer>-214</integer>
                   <key>y</key>
                   <integer>193</integer>
                 </dict>
@@ -487,7 +487,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-256</string>
+                  <integer>-256</integer>
                   <key>y</key>
                   <integer>142</integer>
                 </dict>
@@ -497,7 +497,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-320</string>
+                  <integer>-320</integer>
                   <key>y</key>
                   <integer>142</integer>
                 </dict>
@@ -505,7 +505,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-386</string>
+                  <integer>-386</integer>
                   <key>y</key>
                   <integer>142</integer>
                 </dict>
@@ -513,7 +513,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-422</string>
+                  <integer>-422</integer>
                   <key>y</key>
                   <string>-1.232529278</string>
                 </dict>
@@ -523,7 +523,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-422</string>
+                  <integer>-422</integer>
                   <key>y</key>
                   <integer>273</integer>
                 </dict>
@@ -531,7 +531,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-422</string>
+                  <integer>-422</integer>
                   <key>y</key>
                   <real>357.24</real>
                 </dict>
@@ -539,7 +539,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-386</string>
+                  <integer>-386</integer>
                   <key>y</key>
                   <integer>403</integer>
                 </dict>
@@ -549,7 +549,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-320</string>
+                  <integer>-320</integer>
                   <key>y</key>
                   <integer>403</integer>
                 </dict>
@@ -557,7 +557,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-256</string>
+                  <integer>-256</integer>
                   <key>y</key>
                   <integer>403</integer>
                 </dict>
@@ -565,7 +565,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-214</string>
+                  <integer>-214</integer>
                   <key>y</key>
                   <integer>352</integer>
                 </dict>
@@ -575,7 +575,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-168</string>
+                  <integer>-168</integer>
                   <key>y</key>
                   <integer>301</integer>
                 </dict>
@@ -585,7 +585,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-168</string>
+                  <integer>-168</integer>
                   <key>y</key>
                   <integer>460</integer>
                 </dict>
@@ -593,7 +593,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-219</string>
+                  <integer>-219</integer>
                   <key>y</key>
                   <integer>517</integer>
                 </dict>
@@ -601,7 +601,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-263</string>
+                  <integer>-263</integer>
                   <key>y</key>
                   <integer>562</integer>
                 </dict>
@@ -611,7 +611,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-368</string>
+                  <integer>-368</integer>
                   <key>y</key>
                   <integer>562</integer>
                 </dict>
@@ -619,7 +619,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-511</string>
+                  <integer>-511</integer>
                   <key>y</key>
                   <integer>562</integer>
                 </dict>
@@ -627,7 +627,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-618</string>
+                  <integer>-618</integer>
                   <key>y</key>
                   <integer>467</integer>
                 </dict>
@@ -637,7 +637,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-618</string>
+                  <integer>-618</integer>
                   <key>y</key>
                   <integer>273</integer>
                 </dict>
@@ -705,7 +705,7 @@
                   <key>x</key>
                   <integer>202</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -715,7 +715,7 @@
                   <key>x</key>
                   <integer>343</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -723,7 +723,7 @@
                   <key>x</key>
                   <integer>414</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>

--- a/Source Files/Biryani-Light.ufo/glyphs/da-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/da-deva.glif
@@ -72,7 +72,7 @@
               <key>x</key>
               <integer>288</integer>
               <key>y</key>
-              <string>-80</string>
+              <integer>-80</integer>
             </dict>
             <dict>
               <key>name</key>
@@ -80,7 +80,7 @@
               <key>x</key>
               <integer>415</integer>
               <key>y</key>
-              <string>-15</string>
+              <integer>-15</integer>
             </dict>
             <dict>
               <key>name</key>
@@ -96,7 +96,7 @@
               <key>x</key>
               <integer>288</integer>
               <key>y</key>
-              <string>-80</string>
+              <integer>-80</integer>
             </dict>
             <dict>
               <key>name</key>
@@ -129,7 +129,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-160</string>
+                  <integer>-160</integer>
                   <key>y</key>
                   <integer>214</integer>
                 </dict>
@@ -139,9 +139,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-160</string>
+                  <integer>-160</integer>
                   <key>y</key>
-                  <string>-15</string>
+                  <integer>-15</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -149,9 +149,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-106</string>
+                  <integer>-106</integer>
                   <key>y</key>
-                  <string>-15</string>
+                  <integer>-15</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -159,7 +159,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-106</string>
+                  <integer>-106</integer>
                   <key>y</key>
                   <integer>214</integer>
                 </dict>
@@ -172,7 +172,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-199</string>
+                  <integer>-199</integer>
                   <key>y</key>
                   <integer>74</integer>
                 </dict>
@@ -180,7 +180,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-173</string>
+                  <integer>-173</integer>
                   <key>y</key>
                   <integer>77</integer>
                 </dict>
@@ -190,7 +190,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-145</string>
+                  <integer>-145</integer>
                   <key>y</key>
                   <integer>84</integer>
                 </dict>
@@ -200,7 +200,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-145</string>
+                  <integer>-145</integer>
                   <key>y</key>
                   <integer>130</integer>
                 </dict>
@@ -208,7 +208,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-177</string>
+                  <integer>-177</integer>
                   <key>y</key>
                   <integer>121</integer>
                 </dict>
@@ -216,7 +216,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-201</string>
+                  <integer>-201</integer>
                   <key>y</key>
                   <integer>118</integer>
                 </dict>
@@ -226,7 +226,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-234</string>
+                  <integer>-234</integer>
                   <key>y</key>
                   <integer>118</integer>
                 </dict>
@@ -236,7 +236,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-252</string>
+                  <integer>-252</integer>
                   <key>y</key>
                   <integer>118</integer>
                 </dict>
@@ -244,7 +244,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-355</string>
+                  <integer>-355</integer>
                   <key>y</key>
                   <integer>118</integer>
                 </dict>
@@ -252,7 +252,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-413</string>
+                  <integer>-413</integer>
                   <key>y</key>
                   <integer>145</integer>
                 </dict>
@@ -262,7 +262,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-413</string>
+                  <integer>-413</integer>
                   <key>y</key>
                   <integer>277</integer>
                 </dict>
@@ -270,7 +270,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-413</string>
+                  <integer>-413</integer>
                   <key>y</key>
                   <integer>410</integer>
                 </dict>
@@ -278,7 +278,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-348</string>
+                  <integer>-348</integer>
                   <key>y</key>
                   <integer>436</integer>
                 </dict>
@@ -288,7 +288,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-242</string>
+                  <integer>-242</integer>
                   <key>y</key>
                   <integer>436</integer>
                 </dict>
@@ -298,7 +298,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-130</string>
+                  <integer>-130</integer>
                   <key>y</key>
                   <integer>436</integer>
                 </dict>
@@ -308,7 +308,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-130</string>
+                  <integer>-130</integer>
                   <key>y</key>
                   <integer>480</integer>
                 </dict>
@@ -318,7 +318,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-242</string>
+                  <integer>-242</integer>
                   <key>y</key>
                   <integer>480</integer>
                 </dict>
@@ -326,7 +326,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-390</string>
+                  <integer>-390</integer>
                   <key>y</key>
                   <integer>480</integer>
                 </dict>
@@ -334,7 +334,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-467</string>
+                  <integer>-467</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -344,7 +344,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-467</string>
+                  <integer>-467</integer>
                   <key>y</key>
                   <integer>277</integer>
                 </dict>
@@ -352,7 +352,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-467</string>
+                  <integer>-467</integer>
                   <key>y</key>
                   <integer>125</integer>
                 </dict>
@@ -360,7 +360,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-395</string>
+                  <integer>-395</integer>
                   <key>y</key>
                   <integer>74</integer>
                 </dict>
@@ -370,7 +370,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-252</string>
+                  <integer>-252</integer>
                   <key>y</key>
                   <integer>74</integer>
                 </dict>
@@ -380,7 +380,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-234</string>
+                  <integer>-234</integer>
                   <key>y</key>
                   <integer>74</integer>
                 </dict>
@@ -395,7 +395,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-539</string>
+                  <integer>-539</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -405,7 +405,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-539</string>
+                  <integer>-539</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -415,7 +415,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-184</string>
+                  <integer>-184</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -425,7 +425,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-184</string>
+                  <integer>-184</integer>
                   <key>y</key>
                   <integer>451</integer>
                 </dict>
@@ -435,7 +435,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-130</string>
+                  <integer>-130</integer>
                   <key>y</key>
                   <integer>451</integer>
                 </dict>
@@ -445,7 +445,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-130</string>
+                  <integer>-130</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -455,7 +455,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -465,7 +465,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -746,7 +746,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>674</integer>
                 </dict>
@@ -756,7 +756,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>550</integer>
                 </dict>
@@ -831,7 +831,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-42</string>
+                  <integer>-42</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -841,7 +841,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-42</string>
+                  <integer>-42</integer>
                   <key>y</key>
                   <integer>510</integer>
                 </dict>
@@ -863,7 +863,7 @@
                   <key>x</key>
                   <integer>339</integer>
                   <key>y</key>
-                  <string>-40</string>
+                  <integer>-40</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -873,7 +873,7 @@
                   <key>x</key>
                   <integer>493</integer>
                   <key>y</key>
-                  <string>-40</string>
+                  <integer>-40</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>

--- a/Source Files/Biryani-Light.ufo/glyphs/dd_dda-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/dd_dda-deva.glif
@@ -119,7 +119,7 @@
               <key>x</key>
               <integer>287</integer>
               <key>y</key>
-              <string>-164</string>
+              <integer>-164</integer>
             </dict>
           </array>
           <key>components</key>
@@ -136,7 +136,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -146,7 +146,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -610,7 +610,7 @@
                   <key>x</key>
                   <integer>103</integer>
                   <key>y</key>
-                  <string>-13</string>
+                  <integer>-13</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -620,7 +620,7 @@
                   <key>x</key>
                   <integer>124</integer>
                   <key>y</key>
-                  <string>-29</string>
+                  <integer>-29</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -630,7 +630,7 @@
                   <key>x</key>
                   <integer>280</integer>
                   <key>y</key>
-                  <string>-29</string>
+                  <integer>-29</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -638,7 +638,7 @@
                   <key>x</key>
                   <integer>349</integer>
                   <key>y</key>
-                  <string>-29</string>
+                  <integer>-29</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -646,7 +646,7 @@
                   <key>x</key>
                   <integer>388</integer>
                   <key>y</key>
-                  <string>-45</string>
+                  <integer>-45</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -656,7 +656,7 @@
                   <key>x</key>
                   <integer>390</integer>
                   <key>y</key>
-                  <string>-98</string>
+                  <integer>-98</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -664,7 +664,7 @@
                   <key>x</key>
                   <integer>392</integer>
                   <key>y</key>
-                  <string>-142</string>
+                  <integer>-142</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -672,7 +672,7 @@
                   <key>x</key>
                   <integer>349</integer>
                   <key>y</key>
-                  <string>-163</string>
+                  <integer>-163</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -682,7 +682,7 @@
                   <key>x</key>
                   <integer>280</integer>
                   <key>y</key>
-                  <string>-163</string>
+                  <integer>-163</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -692,7 +692,7 @@
                   <key>x</key>
                   <integer>265</integer>
                   <key>y</key>
-                  <string>-163</string>
+                  <integer>-163</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -700,7 +700,7 @@
                   <key>x</key>
                   <integer>177</integer>
                   <key>y</key>
-                  <string>-163</string>
+                  <integer>-163</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -708,7 +708,7 @@
                   <key>x</key>
                   <integer>114</integer>
                   <key>y</key>
-                  <string>-143</string>
+                  <integer>-143</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -718,7 +718,7 @@
                   <key>x</key>
                   <integer>53</integer>
                   <key>y</key>
-                  <string>-104</string>
+                  <integer>-104</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -728,7 +728,7 @@
                   <key>x</key>
                   <integer>31</integer>
                   <key>y</key>
-                  <string>-144</string>
+                  <integer>-144</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -736,7 +736,7 @@
                   <key>x</key>
                   <integer>95</integer>
                   <key>y</key>
-                  <string>-185</string>
+                  <integer>-185</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -744,7 +744,7 @@
                   <key>x</key>
                   <integer>167</integer>
                   <key>y</key>
-                  <string>-207</string>
+                  <integer>-207</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -754,7 +754,7 @@
                   <key>x</key>
                   <integer>265</integer>
                   <key>y</key>
-                  <string>-207</string>
+                  <integer>-207</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -764,7 +764,7 @@
                   <key>x</key>
                   <integer>280</integer>
                   <key>y</key>
-                  <string>-207</string>
+                  <integer>-207</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -772,7 +772,7 @@
                   <key>x</key>
                   <integer>382</integer>
                   <key>y</key>
-                  <string>-207</string>
+                  <integer>-207</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -780,7 +780,7 @@
                   <key>x</key>
                   <integer>444</integer>
                   <key>y</key>
-                  <string>-169</string>
+                  <integer>-169</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -790,7 +790,7 @@
                   <key>x</key>
                   <integer>444</integer>
                   <key>y</key>
-                  <string>-98</string>
+                  <integer>-98</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -798,7 +798,7 @@
                   <key>x</key>
                   <integer>444</integer>
                   <key>y</key>
-                  <string>-20</string>
+                  <integer>-20</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>

--- a/Source Files/Biryani-Light.ufo/glyphs/dh-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/dh-deva.glif
@@ -68,7 +68,7 @@
               <key>x</key>
               <integer>350</integer>
               <key>y</key>
-              <string>-18</string>
+              <integer>-18</integer>
             </dict>
             <dict>
               <key>name</key>
@@ -99,7 +99,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-272</string>
+                  <integer>-272</integer>
                   <key>y</key>
                   <integer>587</integer>
                 </dict>
@@ -107,7 +107,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-229</string>
+                  <integer>-229</integer>
                   <key>y</key>
                   <integer>603</integer>
                 </dict>
@@ -117,7 +117,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-152</string>
+                  <integer>-152</integer>
                   <key>y</key>
                   <integer>603</integer>
                 </dict>
@@ -127,7 +127,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-140</string>
+                  <integer>-140</integer>
                   <key>y</key>
                   <integer>603</integer>
                 </dict>
@@ -135,7 +135,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-134</string>
+                  <integer>-134</integer>
                   <key>y</key>
                   <integer>603</integer>
                 </dict>
@@ -143,7 +143,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-119</string>
+                  <integer>-119</integer>
                   <key>y</key>
                   <integer>602</integer>
                 </dict>
@@ -153,7 +153,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-109</string>
+                  <integer>-109</integer>
                   <key>y</key>
                   <integer>601</integer>
                 </dict>
@@ -163,7 +163,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-109</string>
+                  <integer>-109</integer>
                   <key>y</key>
                   <integer>645</integer>
                 </dict>
@@ -171,7 +171,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-116</string>
+                  <integer>-116</integer>
                   <key>y</key>
                   <integer>646</integer>
                 </dict>
@@ -179,7 +179,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-129</string>
+                  <integer>-129</integer>
                   <key>y</key>
                   <integer>647</integer>
                 </dict>
@@ -189,7 +189,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-140</string>
+                  <integer>-140</integer>
                   <key>y</key>
                   <integer>647</integer>
                 </dict>
@@ -199,7 +199,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-152</string>
+                  <integer>-152</integer>
                   <key>y</key>
                   <integer>647</integer>
                 </dict>
@@ -207,7 +207,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-268</string>
+                  <integer>-268</integer>
                   <key>y</key>
                   <integer>647</integer>
                 </dict>
@@ -215,7 +215,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-326</string>
+                  <integer>-326</integer>
                   <key>y</key>
                   <integer>611</integer>
                 </dict>
@@ -225,7 +225,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-326</string>
+                  <integer>-326</integer>
                   <key>y</key>
                   <integer>505</integer>
                 </dict>
@@ -233,7 +233,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-326</string>
+                  <integer>-326</integer>
                   <key>y</key>
                   <integer>395</integer>
                 </dict>
@@ -241,7 +241,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-252</string>
+                  <integer>-252</integer>
                   <key>y</key>
                   <integer>362</integer>
                 </dict>
@@ -251,7 +251,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-106</string>
+                  <integer>-106</integer>
                   <key>y</key>
                   <integer>362</integer>
                 </dict>
@@ -261,7 +261,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-88</string>
+                  <integer>-88</integer>
                   <key>y</key>
                   <integer>362</integer>
                 </dict>
@@ -271,7 +271,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-88</string>
+                  <integer>-88</integer>
                   <key>y</key>
                   <integer>406</integer>
                 </dict>
@@ -281,7 +281,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-106</string>
+                  <integer>-106</integer>
                   <key>y</key>
                   <integer>406</integer>
                 </dict>
@@ -289,7 +289,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-212</string>
+                  <integer>-212</integer>
                   <key>y</key>
                   <integer>406</integer>
                 </dict>
@@ -297,7 +297,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-271</string>
+                  <integer>-271</integer>
                   <key>y</key>
                   <integer>419</integer>
                 </dict>
@@ -307,7 +307,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-272</string>
+                  <integer>-272</integer>
                   <key>y</key>
                   <integer>505</integer>
                 </dict>
@@ -320,7 +320,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-236</string>
+                  <integer>-236</integer>
                   <key>y</key>
                   <integer>345</integer>
                 </dict>
@@ -328,7 +328,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-188</string>
+                  <integer>-188</integer>
                   <key>y</key>
                   <integer>362</integer>
                 </dict>
@@ -338,7 +338,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-106</string>
+                  <integer>-106</integer>
                   <key>y</key>
                   <integer>362</integer>
                 </dict>
@@ -348,7 +348,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-77</string>
+                  <integer>-77</integer>
                   <key>y</key>
                   <integer>362</integer>
                 </dict>
@@ -358,7 +358,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-77</string>
+                  <integer>-77</integer>
                   <key>y</key>
                   <integer>406</integer>
                 </dict>
@@ -368,7 +368,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-106</string>
+                  <integer>-106</integer>
                   <key>y</key>
                   <integer>406</integer>
                 </dict>
@@ -376,7 +376,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-228</string>
+                  <integer>-228</integer>
                   <key>y</key>
                   <integer>406</integer>
                 </dict>
@@ -384,7 +384,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-290</string>
+                  <integer>-290</integer>
                   <key>y</key>
                   <integer>369</integer>
                 </dict>
@@ -394,7 +394,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-290</string>
+                  <integer>-290</integer>
                   <key>y</key>
                   <integer>259</integer>
                 </dict>
@@ -402,7 +402,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-290</string>
+                  <integer>-290</integer>
                   <key>y</key>
                   <integer>146</integer>
                 </dict>
@@ -410,7 +410,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-228</string>
+                  <integer>-228</integer>
                   <key>y</key>
                   <integer>113</integer>
                 </dict>
@@ -420,7 +420,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-106</string>
+                  <integer>-106</integer>
                   <key>y</key>
                   <integer>112</integer>
                 </dict>
@@ -430,7 +430,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-88</string>
+                  <integer>-88</integer>
                   <key>y</key>
                   <integer>112</integer>
                 </dict>
@@ -438,7 +438,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-7</string>
+                  <integer>-7</integer>
                   <key>y</key>
                   <integer>112</integer>
                 </dict>
@@ -482,7 +482,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                   <key>y</key>
                   <integer>156</integer>
                 </dict>
@@ -492,7 +492,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-88</string>
+                  <integer>-88</integer>
                   <key>y</key>
                   <integer>156</integer>
                 </dict>
@@ -502,7 +502,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-106</string>
+                  <integer>-106</integer>
                   <key>y</key>
                   <integer>156</integer>
                 </dict>
@@ -510,7 +510,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-189</string>
+                  <integer>-189</integer>
                   <key>y</key>
                   <integer>157</integer>
                 </dict>
@@ -518,7 +518,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-236</string>
+                  <integer>-236</integer>
                   <key>y</key>
                   <integer>169</integer>
                 </dict>
@@ -528,7 +528,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-236</string>
+                  <integer>-236</integer>
                   <key>y</key>
                   <integer>259</integer>
                 </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/dha-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/dha-deva.glif
@@ -85,7 +85,7 @@
               <key>x</key>
               <integer>350</integer>
               <key>y</key>
-              <string>-18</string>
+              <integer>-18</integer>
             </dict>
             <dict>
               <key>name</key>
@@ -687,7 +687,7 @@
                   <key>x</key>
                   <integer>441</integer>
                   <key>y</key>
-                  <string>-23</string>
+                  <integer>-23</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -697,7 +697,7 @@
                   <key>x</key>
                   <integer>595</integer>
                   <key>y</key>
-                  <string>-23</string>
+                  <integer>-23</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>

--- a/Source Files/Biryani-Light.ufo/glyphs/e.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/e.glif
@@ -99,7 +99,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1571</string>
+                  <integer>-1571</integer>
                   <key>y</key>
                   <integer>37</integer>
                 </dict>
@@ -107,7 +107,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1624</string>
+                  <integer>-1624</integer>
                   <key>y</key>
                   <integer>145</integer>
                 </dict>
@@ -117,7 +117,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1624</string>
+                  <integer>-1624</integer>
                   <key>y</key>
                   <integer>275</integer>
                 </dict>
@@ -125,7 +125,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1624</string>
+                  <integer>-1624</integer>
                   <key>y</key>
                   <integer>434</integer>
                 </dict>
@@ -133,7 +133,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1552</string>
+                  <integer>-1552</integer>
                   <key>y</key>
                   <integer>508</integer>
                 </dict>
@@ -143,7 +143,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1442</string>
+                  <integer>-1442</integer>
                   <key>y</key>
                   <integer>508</integer>
                 </dict>
@@ -151,7 +151,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1331</string>
+                  <integer>-1331</integer>
                   <key>y</key>
                   <integer>508</integer>
                 </dict>
@@ -159,7 +159,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1281</string>
+                  <integer>-1281</integer>
                   <key>y</key>
                   <integer>446</integer>
                 </dict>
@@ -169,7 +169,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1281</string>
+                  <integer>-1281</integer>
                   <key>y</key>
                   <integer>310</integer>
                 </dict>
@@ -179,7 +179,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1281</string>
+                  <integer>-1281</integer>
                   <key>y</key>
                   <integer>289</integer>
                 </dict>
@@ -189,7 +189,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1225</string>
+                  <integer>-1225</integer>
                   <key>y</key>
                   <integer>289</integer>
                 </dict>
@@ -199,7 +199,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1225</string>
+                  <integer>-1225</integer>
                   <key>y</key>
                   <integer>310</integer>
                 </dict>
@@ -207,7 +207,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1226</string>
+                  <integer>-1226</integer>
                   <key>y</key>
                   <integer>475</integer>
                 </dict>
@@ -215,7 +215,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1310</string>
+                  <integer>-1310</integer>
                   <key>y</key>
                   <integer>562</integer>
                 </dict>
@@ -225,7 +225,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1442</string>
+                  <integer>-1442</integer>
                   <key>y</key>
                   <integer>562</integer>
                 </dict>
@@ -233,7 +233,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1574</string>
+                  <integer>-1574</integer>
                   <key>y</key>
                   <integer>562</integer>
                 </dict>
@@ -241,7 +241,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1680</string>
+                  <integer>-1680</integer>
                   <key>y</key>
                   <integer>463</integer>
                 </dict>
@@ -251,7 +251,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1680</string>
+                  <integer>-1680</integer>
                   <key>y</key>
                   <integer>274</integer>
                 </dict>
@@ -259,7 +259,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1680</string>
+                  <integer>-1680</integer>
                   <key>y</key>
                   <integer>102</integer>
                 </dict>
@@ -267,9 +267,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1591</string>
+                  <integer>-1591</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -277,25 +277,25 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1422</string>
+                  <integer>-1422</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1359</string>
+                  <integer>-1359</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1296</string>
+                  <integer>-1296</integer>
                   <key>y</key>
-                  <string>-1</string>
+                  <integer>-1</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -303,7 +303,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1239</string>
+                  <integer>-1239</integer>
                   <key>y</key>
                   <integer>28</integer>
                 </dict>
@@ -313,7 +313,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1259</string>
+                  <integer>-1259</integer>
                   <key>y</key>
                   <integer>78</integer>
                 </dict>
@@ -321,7 +321,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1312</string>
+                  <integer>-1312</integer>
                   <key>y</key>
                   <integer>54</integer>
                 </dict>
@@ -329,7 +329,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1367</string>
+                  <integer>-1367</integer>
                   <key>y</key>
                   <integer>37</integer>
                 </dict>
@@ -339,7 +339,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1422</string>
+                  <integer>-1422</integer>
                   <key>y</key>
                   <integer>37</integer>
                 </dict>
@@ -354,7 +354,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1639</string>
+                  <integer>-1639</integer>
                   <key>y</key>
                   <integer>289</integer>
                 </dict>
@@ -364,7 +364,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1270</string>
+                  <integer>-1270</integer>
                   <key>y</key>
                   <integer>289</integer>
                 </dict>
@@ -374,7 +374,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1270</string>
+                  <integer>-1270</integer>
                   <key>y</key>
                   <integer>343</integer>
                 </dict>
@@ -384,7 +384,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1639</string>
+                  <integer>-1639</integer>
                   <key>y</key>
                   <integer>343</integer>
                 </dict>
@@ -397,7 +397,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-999</string>
+                  <integer>-999</integer>
                   <key>y</key>
                   <integer>37</integer>
                 </dict>
@@ -405,7 +405,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1052</string>
+                  <integer>-1052</integer>
                   <key>y</key>
                   <integer>145</integer>
                 </dict>
@@ -415,7 +415,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1052</string>
+                  <integer>-1052</integer>
                   <key>y</key>
                   <integer>275</integer>
                 </dict>
@@ -423,7 +423,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1052</string>
+                  <integer>-1052</integer>
                   <key>y</key>
                   <integer>434</integer>
                 </dict>
@@ -431,7 +431,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-980</string>
+                  <integer>-980</integer>
                   <key>y</key>
                   <integer>508</integer>
                 </dict>
@@ -441,7 +441,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-870</string>
+                  <integer>-870</integer>
                   <key>y</key>
                   <integer>508</integer>
                 </dict>
@@ -449,7 +449,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-759</string>
+                  <integer>-759</integer>
                   <key>y</key>
                   <integer>508</integer>
                 </dict>
@@ -457,7 +457,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-709</string>
+                  <integer>-709</integer>
                   <key>y</key>
                   <integer>446</integer>
                 </dict>
@@ -467,7 +467,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-709</string>
+                  <integer>-709</integer>
                   <key>y</key>
                   <integer>310</integer>
                 </dict>
@@ -477,7 +477,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-709</string>
+                  <integer>-709</integer>
                   <key>y</key>
                   <integer>289</integer>
                 </dict>
@@ -487,7 +487,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-653</string>
+                  <integer>-653</integer>
                   <key>y</key>
                   <integer>289</integer>
                 </dict>
@@ -497,7 +497,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-653</string>
+                  <integer>-653</integer>
                   <key>y</key>
                   <integer>310</integer>
                 </dict>
@@ -505,7 +505,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-654</string>
+                  <integer>-654</integer>
                   <key>y</key>
                   <integer>475</integer>
                 </dict>
@@ -513,7 +513,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-738</string>
+                  <integer>-738</integer>
                   <key>y</key>
                   <integer>562</integer>
                 </dict>
@@ -523,7 +523,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-870</string>
+                  <integer>-870</integer>
                   <key>y</key>
                   <integer>562</integer>
                 </dict>
@@ -531,7 +531,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1002</string>
+                  <integer>-1002</integer>
                   <key>y</key>
                   <integer>562</integer>
                 </dict>
@@ -539,7 +539,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1108</string>
+                  <integer>-1108</integer>
                   <key>y</key>
                   <integer>463</integer>
                 </dict>
@@ -549,7 +549,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1108</string>
+                  <integer>-1108</integer>
                   <key>y</key>
                   <integer>274</integer>
                 </dict>
@@ -557,7 +557,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1108</string>
+                  <integer>-1108</integer>
                   <key>y</key>
                   <integer>102</integer>
                 </dict>
@@ -565,9 +565,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1019</string>
+                  <integer>-1019</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -575,25 +575,25 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-850</string>
+                  <integer>-850</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-787</string>
+                  <integer>-787</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-724</string>
+                  <integer>-724</integer>
                   <key>y</key>
-                  <string>-1</string>
+                  <integer>-1</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -601,7 +601,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-667</string>
+                  <integer>-667</integer>
                   <key>y</key>
                   <integer>28</integer>
                 </dict>
@@ -611,7 +611,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-687</string>
+                  <integer>-687</integer>
                   <key>y</key>
                   <integer>78</integer>
                 </dict>
@@ -619,7 +619,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-740</string>
+                  <integer>-740</integer>
                   <key>y</key>
                   <integer>54</integer>
                 </dict>
@@ -627,7 +627,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-795</string>
+                  <integer>-795</integer>
                   <key>y</key>
                   <integer>37</integer>
                 </dict>
@@ -637,7 +637,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-850</string>
+                  <integer>-850</integer>
                   <key>y</key>
                   <integer>37</integer>
                 </dict>
@@ -652,7 +652,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1067</string>
+                  <integer>-1067</integer>
                   <key>y</key>
                   <integer>289</integer>
                 </dict>
@@ -662,7 +662,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-698</string>
+                  <integer>-698</integer>
                   <key>y</key>
                   <integer>289</integer>
                 </dict>
@@ -672,7 +672,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-698</string>
+                  <integer>-698</integer>
                   <key>y</key>
                   <integer>343</integer>
                 </dict>
@@ -682,7 +682,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1067</string>
+                  <integer>-1067</integer>
                   <key>y</key>
                   <integer>343</integer>
                 </dict>
@@ -695,7 +695,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-320</string>
+                  <integer>-320</integer>
                   <key>y</key>
                   <integer>131</integer>
                 </dict>
@@ -703,7 +703,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-353</string>
+                  <integer>-353</integer>
                   <key>y</key>
                   <integer>175</integer>
                 </dict>
@@ -713,7 +713,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-353</string>
+                  <integer>-353</integer>
                   <key>y</key>
                   <integer>260</integer>
                 </dict>
@@ -723,7 +723,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-353</string>
+                  <integer>-353</integer>
                   <key>y</key>
                   <integer>324</integer>
                 </dict>
@@ -731,7 +731,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-353</string>
+                  <integer>-353</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -739,7 +739,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-319</string>
+                  <integer>-319</integer>
                   <key>y</key>
                   <integer>412</integer>
                 </dict>
@@ -749,7 +749,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-276</string>
+                  <integer>-276</integer>
                   <key>y</key>
                   <integer>412</integer>
                 </dict>
@@ -757,7 +757,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-233</string>
+                  <integer>-233</integer>
                   <key>y</key>
                   <integer>412</integer>
                 </dict>
@@ -765,7 +765,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-200</string>
+                  <integer>-200</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -775,7 +775,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-200</string>
+                  <integer>-200</integer>
                   <key>y</key>
                   <integer>324</integer>
                 </dict>
@@ -785,7 +785,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-200</string>
+                  <integer>-200</integer>
                   <key>y</key>
                   <integer>219</integer>
                 </dict>
@@ -795,7 +795,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-4</string>
+                  <integer>-4</integer>
                   <key>y</key>
                   <integer>219</integer>
                 </dict>
@@ -805,7 +805,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-4</string>
+                  <integer>-4</integer>
                   <key>y</key>
                   <integer>293</integer>
                 </dict>
@@ -813,7 +813,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-4</string>
+                  <integer>-4</integer>
                   <key>y</key>
                   <real>1.128</real>
                 </dict>
@@ -821,7 +821,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-126</string>
+                  <integer>-126</integer>
                   <key>y</key>
                   <integer>562</integer>
                 </dict>
@@ -831,7 +831,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-277</string>
+                  <integer>-277</integer>
                   <key>y</key>
                   <integer>562</integer>
                 </dict>
@@ -839,7 +839,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-427</string>
+                  <integer>-427</integer>
                   <key>y</key>
                   <integer>562</integer>
                 </dict>
@@ -847,7 +847,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-549</string>
+                  <integer>-549</integer>
                   <key>y</key>
                   <integer>468</integer>
                 </dict>
@@ -857,7 +857,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-549</string>
+                  <integer>-549</integer>
                   <key>y</key>
                   <integer>274</integer>
                 </dict>
@@ -865,7 +865,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-549</string>
+                  <integer>-549</integer>
                   <key>y</key>
                   <integer>102</integer>
                 </dict>
@@ -873,9 +873,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-454</string>
+                  <integer>-454</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -883,23 +883,23 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-246</string>
+                  <integer>-246</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-168</string>
+                  <integer>-168</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-90</string>
+                  <integer>-90</integer>
                   <key>y</key>
                   <integer>4</integer>
                 </dict>
@@ -909,7 +909,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-20</string>
+                  <integer>-20</integer>
                   <key>y</key>
                   <integer>46</integer>
                 </dict>
@@ -919,7 +919,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-75</string>
+                  <integer>-75</integer>
                   <key>y</key>
                   <integer>180</integer>
                 </dict>
@@ -927,7 +927,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-127</string>
+                  <integer>-127</integer>
                   <key>y</key>
                   <integer>151</integer>
                 </dict>
@@ -935,7 +935,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-176</string>
+                  <integer>-176</integer>
                   <key>y</key>
                   <integer>131</integer>
                 </dict>
@@ -945,7 +945,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-227</string>
+                  <integer>-227</integer>
                   <key>y</key>
                   <integer>131</integer>
                 </dict>
@@ -960,7 +960,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-458</string>
+                  <integer>-458</integer>
                   <key>y</key>
                   <integer>219</integer>
                 </dict>
@@ -970,7 +970,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-99</string>
+                  <integer>-99</integer>
                   <key>y</key>
                   <integer>219</integer>
                 </dict>
@@ -980,7 +980,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-99</string>
+                  <integer>-99</integer>
                   <key>y</key>
                   <integer>343</integer>
                 </dict>
@@ -990,7 +990,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-458</string>
+                  <integer>-458</integer>
                   <key>y</key>
                   <integer>343</integer>
                 </dict>
@@ -1173,7 +1173,7 @@
                   <key>x</key>
                   <integer>179</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -1183,7 +1183,7 @@
                   <key>x</key>
                   <integer>348</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -1191,7 +1191,7 @@
                   <key>x</key>
                   <integer>411</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -1199,7 +1199,7 @@
                   <key>x</key>
                   <integer>474</integer>
                   <key>y</key>
-                  <string>-1</string>
+                  <integer>-1</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>

--- a/Source Files/Biryani-Light.ufo/glyphs/eC_andraM_atra-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/eC_andraM_atra-deva.glif
@@ -42,7 +42,7 @@
               <key>name</key>
               <string>top</string>
               <key>x</key>
-              <string>-138</string>
+              <integer>-138</integer>
               <key>y</key>
               <integer>784</integer>
             </dict>
@@ -50,7 +50,7 @@
               <key>name</key>
               <string>_top</string>
               <key>x</key>
-              <string>-138</string>
+              <integer>-138</integer>
               <key>y</key>
               <integer>634</integer>
             </dict>
@@ -67,7 +67,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-30</string>
+                  <integer>-30</integer>
                   <key>y</key>
                   <integer>710</integer>
                 </dict>
@@ -105,7 +105,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-3</string>
+                  <integer>-3</integer>
                   <key>y</key>
                   <integer>869</integer>
                 </dict>
@@ -115,7 +115,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-3</string>
+                  <integer>-3</integer>
                   <key>y</key>
                   <integer>859</integer>
                 </dict>
@@ -123,7 +123,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-3</string>
+                  <integer>-3</integer>
                   <key>y</key>
                   <integer>794</integer>
                 </dict>
@@ -131,7 +131,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-47</string>
+                  <integer>-47</integer>
                   <key>y</key>
                   <integer>754</integer>
                 </dict>
@@ -141,7 +141,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-138</string>
+                  <integer>-138</integer>
                   <key>y</key>
                   <integer>754</integer>
                 </dict>
@@ -149,7 +149,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-229</string>
+                  <integer>-229</integer>
                   <key>y</key>
                   <integer>754</integer>
                 </dict>
@@ -157,7 +157,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-273</string>
+                  <integer>-273</integer>
                   <key>y</key>
                   <integer>794</integer>
                 </dict>
@@ -167,7 +167,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-273</string>
+                  <integer>-273</integer>
                   <key>y</key>
                   <integer>859</integer>
                 </dict>
@@ -177,7 +177,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-273</string>
+                  <integer>-273</integer>
                   <key>y</key>
                   <integer>869</integer>
                 </dict>
@@ -187,7 +187,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-317</string>
+                  <integer>-317</integer>
                   <key>y</key>
                   <integer>869</integer>
                 </dict>
@@ -197,7 +197,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-317</string>
+                  <integer>-317</integer>
                   <key>y</key>
                   <integer>859</integer>
                 </dict>
@@ -205,7 +205,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-317</string>
+                  <integer>-317</integer>
                   <key>y</key>
                   <integer>764</integer>
                 </dict>
@@ -213,7 +213,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-246</string>
+                  <integer>-246</integer>
                   <key>y</key>
                   <integer>710</integer>
                 </dict>
@@ -223,7 +223,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-138</string>
+                  <integer>-138</integer>
                   <key>y</key>
                   <integer>710</integer>
                 </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/eM_atra-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/eM_atra-deva.glif
@@ -36,7 +36,7 @@
               <key>name</key>
               <string>top</string>
               <key>x</key>
-              <string>-42</string>
+              <integer>-42</integer>
               <key>y</key>
               <integer>634</integer>
             </dict>
@@ -44,7 +44,7 @@
               <key>name</key>
               <string>_top</string>
               <key>x</key>
-              <string>-138</string>
+              <integer>-138</integer>
               <key>y</key>
               <integer>634</integer>
             </dict>
@@ -63,7 +63,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-109</string>
+                  <integer>-109</integer>
                   <key>y</key>
                   <integer>624</integer>
                 </dict>
@@ -73,7 +73,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-142</string>
+                  <integer>-142</integer>
                   <key>y</key>
                   <integer>769</integer>
                 </dict>
@@ -81,7 +81,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-168</string>
+                  <integer>-168</integer>
                   <key>y</key>
                   <integer>884</integer>
                 </dict>
@@ -89,7 +89,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-217</string>
+                  <integer>-217</integer>
                   <key>y</key>
                   <integer>903</integer>
                 </dict>
@@ -99,7 +99,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-317</string>
+                  <integer>-317</integer>
                   <key>y</key>
                   <integer>903</integer>
                 </dict>
@@ -109,7 +109,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-392</string>
+                  <integer>-392</integer>
                   <key>y</key>
                   <integer>903</integer>
                 </dict>
@@ -119,7 +119,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-392</string>
+                  <integer>-392</integer>
                   <key>y</key>
                   <integer>859</integer>
                 </dict>
@@ -129,7 +129,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-317</string>
+                  <integer>-317</integer>
                   <key>y</key>
                   <integer>859</integer>
                 </dict>
@@ -137,7 +137,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-245</string>
+                  <integer>-245</integer>
                   <key>y</key>
                   <integer>859</integer>
                 </dict>
@@ -145,7 +145,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-212</string>
+                  <integer>-212</integer>
                   <key>y</key>
                   <integer>841</integer>
                 </dict>
@@ -155,7 +155,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-196</string>
+                  <integer>-196</integer>
                   <key>y</key>
                   <integer>769</integer>
                 </dict>
@@ -165,7 +165,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-163</string>
+                  <integer>-163</integer>
                   <key>y</key>
                   <integer>624</integer>
                 </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/eS_hortM_atra-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/eS_hortM_atra-deva.glif
@@ -41,7 +41,7 @@
               <key>name</key>
               <string>_top</string>
               <key>x</key>
-              <string>-138</string>
+              <integer>-138</integer>
               <key>y</key>
               <integer>634</integer>
             </dict>
@@ -58,7 +58,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-591</string>
+                  <integer>-591</integer>
                   <key>y</key>
                   <integer>837</integer>
                 </dict>
@@ -66,7 +66,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-600</string>
+                  <integer>-600</integer>
                   <key>y</key>
                   <integer>875</integer>
                 </dict>
@@ -76,7 +76,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-600</string>
+                  <integer>-600</integer>
                   <key>y</key>
                   <integer>956</integer>
                 </dict>
@@ -86,7 +86,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-600</string>
+                  <integer>-600</integer>
                   <key>y</key>
                   <integer>971</integer>
                 </dict>
@@ -96,7 +96,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-654</string>
+                  <integer>-654</integer>
                   <key>y</key>
                   <integer>971</integer>
                 </dict>
@@ -106,7 +106,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-654</string>
+                  <integer>-654</integer>
                   <key>y</key>
                   <integer>956</integer>
                 </dict>
@@ -114,7 +114,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-654</string>
+                  <integer>-654</integer>
                   <key>y</key>
                   <integer>844</integer>
                 </dict>
@@ -122,7 +122,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-614</string>
+                  <integer>-614</integer>
                   <key>y</key>
                   <integer>793</integer>
                 </dict>
@@ -132,7 +132,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-463</string>
+                  <integer>-463</integer>
                   <key>y</key>
                   <integer>793</integer>
                 </dict>
@@ -142,7 +142,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-296</string>
+                  <integer>-296</integer>
                   <key>y</key>
                   <integer>793</integer>
                 </dict>
@@ -150,7 +150,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-181</string>
+                  <integer>-181</integer>
                   <key>y</key>
                   <integer>793</integer>
                 </dict>
@@ -158,7 +158,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-164</string>
+                  <integer>-164</integer>
                   <key>y</key>
                   <integer>755</integer>
                 </dict>
@@ -168,7 +168,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-164</string>
+                  <integer>-164</integer>
                   <key>y</key>
                   <integer>674</integer>
                 </dict>
@@ -178,7 +178,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-164</string>
+                  <integer>-164</integer>
                   <key>y</key>
                   <integer>624</integer>
                 </dict>
@@ -188,7 +188,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-110</string>
+                  <integer>-110</integer>
                   <key>y</key>
                   <integer>624</integer>
                 </dict>
@@ -198,7 +198,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-110</string>
+                  <integer>-110</integer>
                   <key>y</key>
                   <integer>674</integer>
                 </dict>
@@ -206,7 +206,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-110</string>
+                  <integer>-110</integer>
                   <key>y</key>
                   <integer>786</integer>
                 </dict>
@@ -214,7 +214,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-138</string>
+                  <integer>-138</integer>
                   <key>y</key>
                   <integer>837</integer>
                 </dict>
@@ -224,7 +224,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-296</string>
+                  <integer>-296</integer>
                   <key>y</key>
                   <integer>837</integer>
                 </dict>
@@ -234,7 +234,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-463</string>
+                  <integer>-463</integer>
                   <key>y</key>
                   <integer>837</integer>
                 </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/eth.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/eth.glif
@@ -67,7 +67,7 @@
                   <key>x</key>
                   <integer>496</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -329,7 +329,7 @@
                   <key>x</key>
                   <integer>191</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -339,7 +339,7 @@
                   <key>x</key>
                   <integer>337</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
               </array>
             </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/euro.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/euro.glif
@@ -101,7 +101,7 @@
                   <key>x</key>
                   <integer>185</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -111,7 +111,7 @@
                   <key>x</key>
                   <integer>325</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -119,7 +119,7 @@
                   <key>x</key>
                   <integer>385</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -127,7 +127,7 @@
                   <key>x</key>
                   <integer>424</integer>
                   <key>y</key>
-                  <string>-4</string>
+                  <integer>-4</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>

--- a/Source Files/Biryani-Light.ufo/glyphs/five.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/five.glif
@@ -157,7 +157,7 @@
                   <key>x</key>
                   <integer>386</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -359,7 +359,7 @@
                   <key>x</key>
                   <integer>132</integer>
                   <key>y</key>
-                  <string>-8</string>
+                  <integer>-8</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -367,7 +367,7 @@
                   <key>x</key>
                   <integer>186</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -377,7 +377,7 @@
                   <key>x</key>
                   <integer>240</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
               </array>
             </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/florin.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/florin.glif
@@ -79,7 +79,7 @@
                   <key>x</key>
                   <integer>73</integer>
                   <key>y</key>
-                  <string>-234</string>
+                  <integer>-234</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -89,7 +89,7 @@
                   <key>x</key>
                   <integer>247</integer>
                   <key>y</key>
-                  <string>-234</string>
+                  <integer>-234</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>

--- a/Source Files/Biryani-Light.ufo/glyphs/g-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/g-deva.glif
@@ -199,7 +199,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -209,7 +209,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/g.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/g.glif
@@ -84,7 +84,7 @@
                   <key>x</key>
                   <integer>499</integer>
                   <key>y</key>
-                  <string>-251</string>
+                  <integer>-251</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -92,7 +92,7 @@
                   <key>x</key>
                   <integer>526</integer>
                   <key>y</key>
-                  <string>-150</string>
+                  <integer>-150</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -102,7 +102,7 @@
                   <key>x</key>
                   <integer>526</integer>
                   <key>y</key>
-                  <string>-18</string>
+                  <integer>-18</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -132,7 +132,7 @@
                   <key>x</key>
                   <integer>472</integer>
                   <key>y</key>
-                  <string>-8</string>
+                  <integer>-8</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -140,7 +140,7 @@
                   <key>x</key>
                   <integer>472</integer>
                   <key>y</key>
-                  <string>-126</string>
+                  <integer>-126</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -148,7 +148,7 @@
                   <key>x</key>
                   <integer>462</integer>
                   <key>y</key>
-                  <string>-197</string>
+                  <integer>-197</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -158,7 +158,7 @@
                   <key>x</key>
                   <integer>288</integer>
                   <key>y</key>
-                  <string>-197</string>
+                  <integer>-197</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -166,7 +166,7 @@
                   <key>x</key>
                   <integer>235</integer>
                   <key>y</key>
-                  <string>-197</string>
+                  <integer>-197</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -174,7 +174,7 @@
                   <key>x</key>
                   <integer>178</integer>
                   <key>y</key>
-                  <string>-181</string>
+                  <integer>-181</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -184,7 +184,7 @@
                   <key>x</key>
                   <integer>124</integer>
                   <key>y</key>
-                  <string>-155</string>
+                  <integer>-155</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -194,7 +194,7 @@
                   <key>x</key>
                   <integer>124</integer>
                   <key>y</key>
-                  <string>-215</string>
+                  <integer>-215</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -202,7 +202,7 @@
                   <key>x</key>
                   <integer>185</integer>
                   <key>y</key>
-                  <string>-241</string>
+                  <integer>-241</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -210,7 +210,7 @@
                   <key>x</key>
                   <integer>229</integer>
                   <key>y</key>
-                  <string>-251</string>
+                  <integer>-251</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -220,7 +220,7 @@
                   <key>x</key>
                   <integer>303</integer>
                   <key>y</key>
-                  <string>-251</string>
+                  <integer>-251</integer>
                 </dict>
               </array>
             </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/germandbls.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/germandbls.glif
@@ -294,7 +294,7 @@
                   <key>x</key>
                   <integer>321</integer>
                   <key>y</key>
-                  <string>-11</string>
+                  <integer>-11</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -302,7 +302,7 @@
                   <key>x</key>
                   <integer>356</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -312,7 +312,7 @@
                   <key>x</key>
                   <integer>396</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -320,7 +320,7 @@
                   <key>x</key>
                   <integer>502</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>

--- a/Source Files/Biryani-Light.ufo/glyphs/h.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/h.glif
@@ -100,7 +100,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-941</string>
+                  <integer>-941</integer>
                   <key>y</key>
                   <integer>558</integer>
                 </dict>
@@ -108,7 +108,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1018</string>
+                  <integer>-1018</integer>
                   <key>y</key>
                   <integer>509</integer>
                 </dict>
@@ -118,7 +118,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1068</string>
+                  <integer>-1068</integer>
                   <key>y</key>
                   <integer>451</integer>
                 </dict>
@@ -128,7 +128,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1068</string>
+                  <integer>-1068</integer>
                   <key>y</key>
                   <integer>397</integer>
                 </dict>
@@ -136,7 +136,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1017</string>
+                  <integer>-1017</integer>
                   <key>y</key>
                   <integer>456</integer>
                 </dict>
@@ -144,7 +144,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-945</string>
+                  <integer>-945</integer>
                   <key>y</key>
                   <integer>504</integer>
                 </dict>
@@ -154,7 +154,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-866</string>
+                  <integer>-866</integer>
                   <key>y</key>
                   <integer>504</integer>
                 </dict>
@@ -162,7 +162,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-764</string>
+                  <integer>-764</integer>
                   <key>y</key>
                   <integer>504</integer>
                 </dict>
@@ -170,7 +170,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-731</string>
+                  <integer>-731</integer>
                   <key>y</key>
                   <integer>458</integer>
                 </dict>
@@ -180,7 +180,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-731</string>
+                  <integer>-731</integer>
                   <key>y</key>
                   <integer>330</integer>
                 </dict>
@@ -190,7 +190,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-731</string>
+                  <integer>-731</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -200,7 +200,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-677</string>
+                  <integer>-677</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -210,7 +210,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-677</string>
+                  <integer>-677</integer>
                   <key>y</key>
                   <integer>330</integer>
                 </dict>
@@ -218,7 +218,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-677</string>
+                  <integer>-677</integer>
                   <key>y</key>
                   <integer>499</integer>
                 </dict>
@@ -226,7 +226,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-740</string>
+                  <integer>-740</integer>
                   <key>y</key>
                   <integer>558</integer>
                 </dict>
@@ -236,7 +236,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-866</string>
+                  <integer>-866</integer>
                   <key>y</key>
                   <integer>558</integer>
                 </dict>
@@ -251,7 +251,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1094</string>
+                  <integer>-1094</integer>
                   <key>y</key>
                   <integer>546</integer>
                 </dict>
@@ -261,7 +261,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1094</string>
+                  <integer>-1094</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -271,7 +271,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1040</string>
+                  <integer>-1040</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -281,7 +281,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1040</string>
+                  <integer>-1040</integer>
                   <key>y</key>
                   <integer>546</integer>
                 </dict>
@@ -294,7 +294,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-329</string>
+                  <integer>-329</integer>
                   <key>y</key>
                   <integer>558</integer>
                 </dict>
@@ -302,7 +302,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-406</string>
+                  <integer>-406</integer>
                   <key>y</key>
                   <integer>509</integer>
                 </dict>
@@ -312,7 +312,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-456</string>
+                  <integer>-456</integer>
                   <key>y</key>
                   <integer>451</integer>
                 </dict>
@@ -322,7 +322,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-456</string>
+                  <integer>-456</integer>
                   <key>y</key>
                   <integer>397</integer>
                 </dict>
@@ -330,7 +330,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-405</string>
+                  <integer>-405</integer>
                   <key>y</key>
                   <integer>456</integer>
                 </dict>
@@ -338,7 +338,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-333</string>
+                  <integer>-333</integer>
                   <key>y</key>
                   <integer>504</integer>
                 </dict>
@@ -348,7 +348,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-254</string>
+                  <integer>-254</integer>
                   <key>y</key>
                   <integer>504</integer>
                 </dict>
@@ -356,7 +356,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-152</string>
+                  <integer>-152</integer>
                   <key>y</key>
                   <integer>504</integer>
                 </dict>
@@ -364,7 +364,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-119</string>
+                  <integer>-119</integer>
                   <key>y</key>
                   <integer>458</integer>
                 </dict>
@@ -374,7 +374,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-119</string>
+                  <integer>-119</integer>
                   <key>y</key>
                   <integer>330</integer>
                 </dict>
@@ -384,7 +384,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-119</string>
+                  <integer>-119</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -394,7 +394,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-65</string>
+                  <integer>-65</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -404,7 +404,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-65</string>
+                  <integer>-65</integer>
                   <key>y</key>
                   <integer>330</integer>
                 </dict>
@@ -412,7 +412,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-65</string>
+                  <integer>-65</integer>
                   <key>y</key>
                   <integer>499</integer>
                 </dict>
@@ -420,7 +420,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-128</string>
+                  <integer>-128</integer>
                   <key>y</key>
                   <integer>558</integer>
                 </dict>
@@ -430,7 +430,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-254</string>
+                  <integer>-254</integer>
                   <key>y</key>
                   <integer>558</integer>
                 </dict>
@@ -445,7 +445,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-482</string>
+                  <integer>-482</integer>
                   <key>y</key>
                   <integer>846</integer>
                 </dict>
@@ -455,7 +455,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-482</string>
+                  <integer>-482</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -465,7 +465,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-428</string>
+                  <integer>-428</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -475,7 +475,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-428</string>
+                  <integer>-428</integer>
                   <key>y</key>
                   <integer>846</integer>
                 </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/h_na-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/h_na-deva.glif
@@ -188,7 +188,7 @@
                   <key>x</key>
                   <integer>259</integer>
                   <key>y</key>
-                  <string>-69</string>
+                  <integer>-69</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -196,7 +196,7 @@
                   <key>x</key>
                   <integer>293</integer>
                   <key>y</key>
-                  <string>-117</string>
+                  <integer>-117</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -206,7 +206,7 @@
                   <key>x</key>
                   <integer>394</integer>
                   <key>y</key>
-                  <string>-154</string>
+                  <integer>-154</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -216,7 +216,7 @@
                   <key>x</key>
                   <integer>457</integer>
                   <key>y</key>
-                  <string>-51</string>
+                  <integer>-51</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -224,7 +224,7 @@
                   <key>x</key>
                   <integer>421</integer>
                   <key>y</key>
-                  <string>-38</string>
+                  <integer>-38</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -232,7 +232,7 @@
                   <key>x</key>
                   <integer>404</integer>
                   <key>y</key>
-                  <string>-19</string>
+                  <integer>-19</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>

--- a/Source Files/Biryani-Light.ufo/glyphs/ha_uM_atra-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/ha_uM_atra-deva.glif
@@ -110,7 +110,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>674</integer>
                 </dict>
@@ -120,7 +120,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>550</integer>
                 </dict>
@@ -526,7 +526,7 @@
                   <key>x</key>
                   <integer>272</integer>
                   <key>y</key>
-                  <string>-44</string>
+                  <integer>-44</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -536,7 +536,7 @@
                   <key>x</key>
                   <integer>328</integer>
                   <key>y</key>
-                  <string>-56</string>
+                  <integer>-56</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -552,7 +552,7 @@
                   <key>x</key>
                   <integer>409</integer>
                   <key>y</key>
-                  <string>-79</string>
+                  <integer>-79</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -562,7 +562,7 @@
                   <key>x</key>
                   <integer>409</integer>
                   <key>y</key>
-                  <string>-110</string>
+                  <integer>-110</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -570,7 +570,7 @@
                   <key>x</key>
                   <integer>409</integer>
                   <key>y</key>
-                  <string>-141</string>
+                  <integer>-141</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -578,7 +578,7 @@
                   <key>x</key>
                   <integer>379</integer>
                   <key>y</key>
-                  <string>-155</string>
+                  <integer>-155</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -588,7 +588,7 @@
                   <key>x</key>
                   <integer>322</integer>
                   <key>y</key>
-                  <string>-155</string>
+                  <integer>-155</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -596,7 +596,7 @@
                   <key>x</key>
                   <integer>213</integer>
                   <key>y</key>
-                  <string>-155</string>
+                  <integer>-155</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -604,7 +604,7 @@
                   <key>x</key>
                   <integer>133</integer>
                   <key>y</key>
-                  <string>-105</string>
+                  <integer>-105</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -614,7 +614,7 @@
                   <key>x</key>
                   <integer>61</integer>
                   <key>y</key>
-                  <string>-40</string>
+                  <integer>-40</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -622,9 +622,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-21</string>
+                  <integer>-21</integer>
                   <key>y</key>
-                  <string>-135</string>
+                  <integer>-135</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -632,7 +632,7 @@
                   <key>x</key>
                   <integer>54</integer>
                   <key>y</key>
-                  <string>-207</string>
+                  <integer>-207</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -640,7 +640,7 @@
                   <key>x</key>
                   <integer>172</integer>
                   <key>y</key>
-                  <string>-279</string>
+                  <integer>-279</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -650,7 +650,7 @@
                   <key>x</key>
                   <integer>332</integer>
                   <key>y</key>
-                  <string>-279</string>
+                  <integer>-279</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -658,7 +658,7 @@
                   <key>x</key>
                   <integer>469</integer>
                   <key>y</key>
-                  <string>-279</string>
+                  <integer>-279</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -676,7 +676,7 @@
                   <key>x</key>
                   <integer>563</integer>
                   <key>y</key>
-                  <string>-98</string>
+                  <integer>-98</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>

--- a/Source Files/Biryani-Light.ufo/glyphs/i-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/i-deva.glif
@@ -102,7 +102,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-255</string>
+                  <integer>-255</integer>
                   <key>y</key>
                   <integer>470</integer>
                 </dict>
@@ -110,7 +110,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-351</string>
+                  <integer>-351</integer>
                   <key>y</key>
                   <integer>470</integer>
                 </dict>
@@ -118,7 +118,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-399</string>
+                  <integer>-399</integer>
                   <key>y</key>
                   <integer>440</integer>
                 </dict>
@@ -128,7 +128,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-399</string>
+                  <integer>-399</integer>
                   <key>y</key>
                   <integer>358</integer>
                 </dict>
@@ -136,7 +136,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-399</string>
+                  <integer>-399</integer>
                   <key>y</key>
                   <integer>304</integer>
                 </dict>
@@ -144,7 +144,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-362</string>
+                  <integer>-362</integer>
                   <key>y</key>
                   <integer>262</integer>
                 </dict>
@@ -154,7 +154,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-341</string>
+                  <integer>-341</integer>
                   <key>y</key>
                   <integer>246</integer>
                 </dict>
@@ -164,7 +164,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-185</string>
+                  <integer>-185</integer>
                   <key>y</key>
                   <integer>246</integer>
                 </dict>
@@ -172,7 +172,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-116</string>
+                  <integer>-116</integer>
                   <key>y</key>
                   <integer>246</integer>
                 </dict>
@@ -180,7 +180,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-77</string>
+                  <integer>-77</integer>
                   <key>y</key>
                   <integer>224</integer>
                 </dict>
@@ -190,7 +190,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-75</string>
+                  <integer>-75</integer>
                   <key>y</key>
                   <integer>157</integer>
                 </dict>
@@ -198,7 +198,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-73</string>
+                  <integer>-73</integer>
                   <key>y</key>
                   <integer>94</integer>
                 </dict>
@@ -206,7 +206,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-116</string>
+                  <integer>-116</integer>
                   <key>y</key>
                   <integer>67</integer>
                 </dict>
@@ -216,7 +216,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-185</string>
+                  <integer>-185</integer>
                   <key>y</key>
                   <integer>67</integer>
                 </dict>
@@ -226,7 +226,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-200</string>
+                  <integer>-200</integer>
                   <key>y</key>
                   <integer>67</integer>
                 </dict>
@@ -234,7 +234,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-268</string>
+                  <integer>-268</integer>
                   <key>y</key>
                   <integer>67</integer>
                 </dict>
@@ -242,7 +242,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-317</string>
+                  <integer>-317</integer>
                   <key>y</key>
                   <integer>85</integer>
                 </dict>
@@ -252,7 +252,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-364</string>
+                  <integer>-364</integer>
                   <key>y</key>
                   <integer>115</integer>
                 </dict>
@@ -262,7 +262,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-382</string>
+                  <integer>-382</integer>
                   <key>y</key>
                   <integer>73</integer>
                 </dict>
@@ -270,7 +270,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-332</string>
+                  <integer>-332</integer>
                   <key>y</key>
                   <integer>42</integer>
                 </dict>
@@ -278,7 +278,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-276</string>
+                  <integer>-276</integer>
                   <key>y</key>
                   <integer>23</integer>
                 </dict>
@@ -288,7 +288,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-200</string>
+                  <integer>-200</integer>
                   <key>y</key>
                   <integer>23</integer>
                 </dict>
@@ -298,7 +298,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-185</string>
+                  <integer>-185</integer>
                   <key>y</key>
                   <integer>23</integer>
                 </dict>
@@ -306,7 +306,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-83</string>
+                  <integer>-83</integer>
                   <key>y</key>
                   <integer>23</integer>
                 </dict>
@@ -314,7 +314,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-21</string>
+                  <integer>-21</integer>
                   <key>y</key>
                   <integer>69</integer>
                 </dict>
@@ -324,7 +324,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-21</string>
+                  <integer>-21</integer>
                   <key>y</key>
                   <integer>157</integer>
                 </dict>
@@ -332,7 +332,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-21</string>
+                  <integer>-21</integer>
                   <key>y</key>
                   <integer>248</integer>
                 </dict>
@@ -340,7 +340,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-83</string>
+                  <integer>-83</integer>
                   <key>y</key>
                   <integer>290</integer>
                 </dict>
@@ -350,7 +350,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-185</string>
+                  <integer>-185</integer>
                   <key>y</key>
                   <integer>290</integer>
                 </dict>
@@ -360,7 +360,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-315</string>
+                  <integer>-315</integer>
                   <key>y</key>
                   <integer>290</integer>
                 </dict>
@@ -368,7 +368,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-330</string>
+                  <integer>-330</integer>
                   <key>y</key>
                   <integer>300</integer>
                 </dict>
@@ -376,7 +376,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-345</string>
+                  <integer>-345</integer>
                   <key>y</key>
                   <integer>323</integer>
                 </dict>
@@ -386,7 +386,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-345</string>
+                  <integer>-345</integer>
                   <key>y</key>
                   <integer>358</integer>
                 </dict>
@@ -394,7 +394,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-345</string>
+                  <integer>-345</integer>
                   <key>y</key>
                   <integer>412</integer>
                 </dict>
@@ -402,7 +402,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-313</string>
+                  <integer>-313</integer>
                   <key>y</key>
                   <integer>426</integer>
                 </dict>
@@ -412,7 +412,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-255</string>
+                  <integer>-255</integer>
                   <key>y</key>
                   <integer>426</integer>
                 </dict>
@@ -422,7 +422,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-91</string>
+                  <integer>-91</integer>
                   <key>y</key>
                   <integer>426</integer>
                 </dict>
@@ -432,7 +432,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-91</string>
+                  <integer>-91</integer>
                   <key>y</key>
                   <integer>470</integer>
                 </dict>
@@ -447,7 +447,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-399</string>
+                  <integer>-399</integer>
                   <key>y</key>
                   <integer>174</integer>
                 </dict>
@@ -457,9 +457,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-399</string>
+                  <integer>-399</integer>
                   <key>y</key>
-                  <string>-55</string>
+                  <integer>-55</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -467,9 +467,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-345</string>
+                  <integer>-345</integer>
                   <key>y</key>
-                  <string>-55</string>
+                  <integer>-55</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -477,7 +477,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-345</string>
+                  <integer>-345</integer>
                   <key>y</key>
                   <integer>174</integer>
                 </dict>
@@ -492,7 +492,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-482</string>
+                  <integer>-482</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -502,7 +502,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-482</string>
+                  <integer>-482</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -512,7 +512,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-145</string>
+                  <integer>-145</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -522,7 +522,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-145</string>
+                  <integer>-145</integer>
                   <key>y</key>
                   <integer>440</integer>
                 </dict>
@@ -532,7 +532,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-91</string>
+                  <integer>-91</integer>
                   <key>y</key>
                   <integer>440</integer>
                 </dict>
@@ -542,7 +542,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-91</string>
+                  <integer>-91</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -934,7 +934,7 @@
                   <key>x</key>
                   <integer>103</integer>
                   <key>y</key>
-                  <string>-55</string>
+                  <integer>-55</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -944,7 +944,7 @@
                   <key>x</key>
                   <integer>157</integer>
                   <key>y</key>
-                  <string>-55</string>
+                  <integer>-55</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>

--- a/Source Files/Biryani-Light.ufo/glyphs/iM_atra-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/iM_atra-deva.glif
@@ -333,7 +333,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-11</string>
+                  <integer>-11</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -343,7 +343,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-11</string>
+                  <integer>-11</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -423,7 +423,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-11</string>
+                  <integer>-11</integer>
                   <key>y</key>
                   <integer>674</integer>
                 </dict>
@@ -433,7 +433,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-11</string>
+                  <integer>-11</integer>
                   <key>y</key>
                   <integer>550</integer>
                 </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/iiM_atra-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/iiM_atra-deva.glif
@@ -56,7 +56,7 @@
               <key>name</key>
               <string>iimatra</string>
               <key>x</key>
-              <string>-164</string>
+              <integer>-164</integer>
               <key>y</key>
               <integer>608</integer>
             </dict>
@@ -97,7 +97,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-119</string>
+                  <integer>-119</integer>
                   <key>y</key>
                   <integer>923</integer>
                 </dict>
@@ -105,7 +105,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-164</string>
+                  <integer>-164</integer>
                   <key>y</key>
                   <integer>876</integer>
                 </dict>
@@ -115,7 +115,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-164</string>
+                  <integer>-164</integer>
                   <key>y</key>
                   <integer>725</integer>
                 </dict>
@@ -125,7 +125,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-164</string>
+                  <integer>-164</integer>
                   <key>y</key>
                   <integer>608</integer>
                 </dict>
@@ -135,7 +135,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-110</string>
+                  <integer>-110</integer>
                   <key>y</key>
                   <integer>608</integer>
                 </dict>
@@ -145,7 +145,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-110</string>
+                  <integer>-110</integer>
                   <key>y</key>
                   <integer>725</integer>
                 </dict>
@@ -153,7 +153,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-110</string>
+                  <integer>-110</integer>
                   <key>y</key>
                   <integer>865</integer>
                 </dict>
@@ -161,7 +161,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-74</string>
+                  <integer>-74</integer>
                   <key>y</key>
                   <integer>879</integer>
                 </dict>
@@ -171,7 +171,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-11</string>
+                  <integer>-11</integer>
                   <key>y</key>
                   <integer>879</integer>
                 </dict>
@@ -273,7 +273,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-11</string>
+                  <integer>-11</integer>
                   <key>y</key>
                   <integer>923</integer>
                 </dict>
@@ -333,7 +333,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -363,7 +363,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -423,7 +423,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>674</integer>
                 </dict>
@@ -433,7 +433,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>550</integer>
                 </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/j-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/j-deva.glif
@@ -58,7 +58,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -68,7 +68,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/ja_halant_nya_halant-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/ja_halant_nya_halant-deva.glif
@@ -72,7 +72,7 @@
               <key>x</key>
               <integer>267</integer>
               <key>y</key>
-              <string>-62</string>
+              <integer>-62</integer>
             </dict>
           </array>
           <key>components</key>
@@ -446,7 +446,7 @@
                   <key>x</key>
                   <integer>73</integer>
                   <key>y</key>
-                  <string>-35</string>
+                  <integer>-35</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -456,7 +456,7 @@
                   <key>x</key>
                   <integer>127</integer>
                   <key>y</key>
-                  <string>-35</string>
+                  <integer>-35</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -479,7 +479,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -489,7 +489,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/jh_r-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/jh_r-deva.glif
@@ -513,7 +513,7 @@
                   <key>x</key>
                   <integer>73</integer>
                   <key>y</key>
-                  <string>-35</string>
+                  <integer>-35</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -523,7 +523,7 @@
                   <key>x</key>
                   <integer>127</integer>
                   <key>y</key>
-                  <string>-35</string>
+                  <integer>-35</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -546,7 +546,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -556,7 +556,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -688,7 +688,7 @@
                   <key>x</key>
                   <integer>453</integer>
                   <key>y</key>
-                  <string>-16</string>
+                  <integer>-16</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>

--- a/Source Files/Biryani-Light.ufo/glyphs/jh_ra-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/jh_ra-deva.glif
@@ -522,7 +522,7 @@
                   <key>x</key>
                   <integer>73</integer>
                   <key>y</key>
-                  <string>-35</string>
+                  <integer>-35</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -532,7 +532,7 @@
                   <key>x</key>
                   <integer>127</integer>
                   <key>y</key>
-                  <string>-35</string>
+                  <integer>-35</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -555,7 +555,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -565,7 +565,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -697,7 +697,7 @@
                   <key>x</key>
                   <integer>453</integer>
                   <key>y</key>
-                  <string>-16</string>
+                  <integer>-16</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>

--- a/Source Files/Biryani-Light.ufo/glyphs/jha-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/jha-deva.glif
@@ -95,7 +95,7 @@
               <key>x</key>
               <integer>267</integer>
               <key>y</key>
-              <string>-62</string>
+              <integer>-62</integer>
             </dict>
             <dict>
               <key>name</key>
@@ -530,7 +530,7 @@
                   <key>x</key>
                   <integer>73</integer>
                   <key>y</key>
-                  <string>-35</string>
+                  <integer>-35</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -540,7 +540,7 @@
                   <key>x</key>
                   <integer>127</integer>
                   <key>y</key>
-                  <string>-35</string>
+                  <integer>-35</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -563,7 +563,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -573,7 +573,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/k-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/k-deva.glif
@@ -350,7 +350,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -360,7 +360,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/k.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/k.glif
@@ -80,7 +80,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-40</string>
+                  <integer>-40</integer>
                   <key>y</key>
                   <integer>546</integer>
                 </dict>
@@ -90,7 +90,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-112</string>
+                  <integer>-112</integer>
                   <key>y</key>
                   <integer>546</integer>
                 </dict>
@@ -100,7 +100,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-371</string>
+                  <integer>-371</integer>
                   <key>y</key>
                   <integer>285</integer>
                 </dict>
@@ -110,7 +110,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-371</string>
+                  <integer>-371</integer>
                   <key>y</key>
                   <integer>213</integer>
                 </dict>
@@ -125,7 +125,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-417</string>
+                  <integer>-417</integer>
                   <key>y</key>
                   <integer>846</integer>
                 </dict>
@@ -135,7 +135,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-417</string>
+                  <integer>-417</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -145,7 +145,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-363</string>
+                  <integer>-363</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -155,7 +155,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-363</string>
+                  <integer>-363</integer>
                   <key>y</key>
                   <integer>846</integer>
                 </dict>
@@ -170,7 +170,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-307</string>
+                  <integer>-307</integer>
                   <key>y</key>
                   <integer>303</integer>
                 </dict>
@@ -180,7 +180,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-68</string>
+                  <integer>-68</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -200,7 +200,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-268</string>
+                  <integer>-268</integer>
                   <key>y</key>
                   <integer>340</integer>
                 </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/k_ss-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/k_ss-deva.glif
@@ -419,7 +419,7 @@
                   <key>x</key>
                   <integer>376</integer>
                   <key>y</key>
-                  <string>-55</string>
+                  <integer>-55</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -449,7 +449,7 @@
                   <key>x</key>
                   <integer>322</integer>
                   <key>y</key>
-                  <string>-55</string>
+                  <integer>-55</integer>
                 </dict>
               </array>
             </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/k_ss_r-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/k_ss_r-deva.glif
@@ -426,7 +426,7 @@
                   <key>x</key>
                   <integer>376</integer>
                   <key>y</key>
-                  <string>-55</string>
+                  <integer>-55</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -456,7 +456,7 @@
                   <key>x</key>
                   <integer>322</integer>
                   <key>y</key>
-                  <string>-55</string>
+                  <integer>-55</integer>
                 </dict>
               </array>
             </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/k_ss_ra-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/k_ss_ra-deva.glif
@@ -116,7 +116,7 @@
                   <key>x</key>
                   <integer>376</integer>
                   <key>y</key>
-                  <string>-55</string>
+                  <integer>-55</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -146,7 +146,7 @@
                   <key>x</key>
                   <integer>322</integer>
                   <key>y</key>
-                  <string>-55</string>
+                  <integer>-55</integer>
                 </dict>
               </array>
             </dict>
@@ -301,7 +301,7 @@
                   <key>x</key>
                   <integer>460</integer>
                   <key>y</key>
-                  <string>-16</string>
+                  <integer>-16</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>

--- a/Source Files/Biryani-Light.ufo/glyphs/k_ssa-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/k_ssa-deva.glif
@@ -435,7 +435,7 @@
                   <key>x</key>
                   <integer>376</integer>
                   <key>y</key>
-                  <string>-55</string>
+                  <integer>-55</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -465,7 +465,7 @@
                   <key>x</key>
                   <integer>322</integer>
                   <key>y</key>
-                  <string>-55</string>
+                  <integer>-55</integer>
                 </dict>
               </array>
             </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/k_ta-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/k_ta-deva.glif
@@ -94,7 +94,7 @@
               <key>x</key>
               <integer>188</integer>
               <key>y</key>
-              <string>-103</string>
+              <integer>-103</integer>
             </dict>
             <dict>
               <key>name</key>

--- a/Source Files/Biryani-Light.ufo/glyphs/ka-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/ka-deva.glif
@@ -156,7 +156,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-775</string>
+                  <integer>-775</integer>
                   <key>y</key>
                   <integer>368</integer>
                 </dict>
@@ -164,7 +164,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-727</string>
+                  <integer>-727</integer>
                   <key>y</key>
                   <integer>385</integer>
                 </dict>
@@ -174,7 +174,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-645</string>
+                  <integer>-645</integer>
                   <key>y</key>
                   <integer>385</integer>
                 </dict>
@@ -184,7 +184,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-633</string>
+                  <integer>-633</integer>
                   <key>y</key>
                   <integer>385</integer>
                 </dict>
@@ -192,7 +192,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-615</string>
+                  <integer>-615</integer>
                   <key>y</key>
                   <integer>385</integer>
                 </dict>
@@ -200,7 +200,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-591</string>
+                  <integer>-591</integer>
                   <key>y</key>
                   <integer>383</integer>
                 </dict>
@@ -210,7 +210,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-573</string>
+                  <integer>-573</integer>
                   <key>y</key>
                   <integer>379</integer>
                 </dict>
@@ -220,7 +220,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-573</string>
+                  <integer>-573</integer>
                   <key>y</key>
                   <integer>424</integer>
                 </dict>
@@ -228,7 +228,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-584</string>
+                  <integer>-584</integer>
                   <key>y</key>
                   <integer>426</integer>
                 </dict>
@@ -236,7 +236,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-615</string>
+                  <integer>-615</integer>
                   <key>y</key>
                   <integer>429</integer>
                 </dict>
@@ -246,7 +246,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-633</string>
+                  <integer>-633</integer>
                   <key>y</key>
                   <integer>429</integer>
                 </dict>
@@ -256,7 +256,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-645</string>
+                  <integer>-645</integer>
                   <key>y</key>
                   <integer>429</integer>
                 </dict>
@@ -264,7 +264,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-767</string>
+                  <integer>-767</integer>
                   <key>y</key>
                   <integer>429</integer>
                 </dict>
@@ -272,7 +272,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-829</string>
+                  <integer>-829</integer>
                   <key>y</key>
                   <integer>392</integer>
                 </dict>
@@ -282,7 +282,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-829</string>
+                  <integer>-829</integer>
                   <key>y</key>
                   <integer>282</integer>
                 </dict>
@@ -290,7 +290,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-829</string>
+                  <integer>-829</integer>
                   <key>y</key>
                   <integer>169</integer>
                 </dict>
@@ -298,7 +298,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-767</string>
+                  <integer>-767</integer>
                   <key>y</key>
                   <integer>136</integer>
                 </dict>
@@ -308,7 +308,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-645</string>
+                  <integer>-645</integer>
                   <key>y</key>
                   <integer>135</integer>
                 </dict>
@@ -318,7 +318,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-627</string>
+                  <integer>-627</integer>
                   <key>y</key>
                   <integer>135</integer>
                 </dict>
@@ -326,7 +326,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-589</string>
+                  <integer>-589</integer>
                   <key>y</key>
                   <integer>135</integer>
                 </dict>
@@ -334,7 +334,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-526</string>
+                  <integer>-526</integer>
                   <key>y</key>
                   <integer>140</integer>
                 </dict>
@@ -344,7 +344,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-478</string>
+                  <integer>-478</integer>
                   <key>y</key>
                   <integer>180</integer>
                 </dict>
@@ -354,7 +354,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-478</string>
+                  <integer>-478</integer>
                   <key>y</key>
                   <integer>229</integer>
                 </dict>
@@ -362,7 +362,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-526</string>
+                  <integer>-526</integer>
                   <key>y</key>
                   <integer>189</integer>
                 </dict>
@@ -370,7 +370,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-577</string>
+                  <integer>-577</integer>
                   <key>y</key>
                   <integer>179</integer>
                 </dict>
@@ -380,7 +380,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-627</string>
+                  <integer>-627</integer>
                   <key>y</key>
                   <integer>179</integer>
                 </dict>
@@ -390,7 +390,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-645</string>
+                  <integer>-645</integer>
                   <key>y</key>
                   <integer>179</integer>
                 </dict>
@@ -398,7 +398,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-728</string>
+                  <integer>-728</integer>
                   <key>y</key>
                   <integer>180</integer>
                 </dict>
@@ -406,7 +406,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-775</string>
+                  <integer>-775</integer>
                   <key>y</key>
                   <integer>192</integer>
                 </dict>
@@ -416,7 +416,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-775</string>
+                  <integer>-775</integer>
                   <key>y</key>
                   <integer>282</integer>
                 </dict>
@@ -429,7 +429,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-181</string>
+                  <integer>-181</integer>
                   <key>y</key>
                   <integer>196</integer>
                 </dict>
@@ -437,7 +437,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-229</string>
+                  <integer>-229</integer>
                   <key>y</key>
                   <integer>179</integer>
                 </dict>
@@ -447,7 +447,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-311</string>
+                  <integer>-311</integer>
                   <key>y</key>
                   <integer>179</integer>
                 </dict>
@@ -457,7 +457,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-323</string>
+                  <integer>-323</integer>
                   <key>y</key>
                   <integer>179</integer>
                 </dict>
@@ -465,7 +465,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-341</string>
+                  <integer>-341</integer>
                   <key>y</key>
                   <integer>179</integer>
                 </dict>
@@ -473,7 +473,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-365</string>
+                  <integer>-365</integer>
                   <key>y</key>
                   <integer>181</integer>
                 </dict>
@@ -483,7 +483,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-383</string>
+                  <integer>-383</integer>
                   <key>y</key>
                   <integer>185</integer>
                 </dict>
@@ -493,7 +493,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-383</string>
+                  <integer>-383</integer>
                   <key>y</key>
                   <integer>140</integer>
                 </dict>
@@ -501,7 +501,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-372</string>
+                  <integer>-372</integer>
                   <key>y</key>
                   <integer>138</integer>
                 </dict>
@@ -509,7 +509,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-341</string>
+                  <integer>-341</integer>
                   <key>y</key>
                   <integer>135</integer>
                 </dict>
@@ -519,7 +519,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-323</string>
+                  <integer>-323</integer>
                   <key>y</key>
                   <integer>135</integer>
                 </dict>
@@ -529,7 +529,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-311</string>
+                  <integer>-311</integer>
                   <key>y</key>
                   <integer>135</integer>
                 </dict>
@@ -537,7 +537,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-189</string>
+                  <integer>-189</integer>
                   <key>y</key>
                   <integer>135</integer>
                 </dict>
@@ -545,7 +545,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-127</string>
+                  <integer>-127</integer>
                   <key>y</key>
                   <integer>172</integer>
                 </dict>
@@ -555,7 +555,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-127</string>
+                  <integer>-127</integer>
                   <key>y</key>
                   <integer>282</integer>
                 </dict>
@@ -563,7 +563,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-127</string>
+                  <integer>-127</integer>
                   <key>y</key>
                   <integer>395</integer>
                 </dict>
@@ -571,7 +571,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-189</string>
+                  <integer>-189</integer>
                   <key>y</key>
                   <integer>428</integer>
                 </dict>
@@ -581,7 +581,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-311</string>
+                  <integer>-311</integer>
                   <key>y</key>
                   <integer>429</integer>
                 </dict>
@@ -591,7 +591,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-329</string>
+                  <integer>-329</integer>
                   <key>y</key>
                   <integer>429</integer>
                 </dict>
@@ -599,7 +599,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-367</string>
+                  <integer>-367</integer>
                   <key>y</key>
                   <integer>429</integer>
                 </dict>
@@ -607,7 +607,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-430</string>
+                  <integer>-430</integer>
                   <key>y</key>
                   <integer>424</integer>
                 </dict>
@@ -617,7 +617,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-478</string>
+                  <integer>-478</integer>
                   <key>y</key>
                   <integer>384</integer>
                 </dict>
@@ -627,7 +627,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-478</string>
+                  <integer>-478</integer>
                   <key>y</key>
                   <integer>335</integer>
                 </dict>
@@ -635,7 +635,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-430</string>
+                  <integer>-430</integer>
                   <key>y</key>
                   <integer>375</integer>
                 </dict>
@@ -643,7 +643,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-379</string>
+                  <integer>-379</integer>
                   <key>y</key>
                   <integer>385</integer>
                 </dict>
@@ -653,7 +653,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-329</string>
+                  <integer>-329</integer>
                   <key>y</key>
                   <integer>385</integer>
                 </dict>
@@ -663,7 +663,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-311</string>
+                  <integer>-311</integer>
                   <key>y</key>
                   <integer>385</integer>
                 </dict>
@@ -671,7 +671,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-228</string>
+                  <integer>-228</integer>
                   <key>y</key>
                   <integer>384</integer>
                 </dict>
@@ -679,7 +679,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-181</string>
+                  <integer>-181</integer>
                   <key>y</key>
                   <integer>372</integer>
                 </dict>
@@ -689,7 +689,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-181</string>
+                  <integer>-181</integer>
                   <key>y</key>
                   <integer>282</integer>
                 </dict>
@@ -704,7 +704,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-886</string>
+                  <integer>-886</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -714,7 +714,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-886</string>
+                  <integer>-886</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -724,7 +724,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-505</string>
+                  <integer>-505</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -734,7 +734,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-505</string>
+                  <integer>-505</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -744,7 +744,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-451</string>
+                  <integer>-451</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -754,17 +754,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-451</string>
-                  <key>y</key>
-                  <integer>590</integer>
-                </dict>
-                <dict>
-                  <key>segmentType</key>
-                  <string>line</string>
-                  <key>smooth</key>
-                  <integer>0</integer>
-                  <key>x</key>
-                  <string>-70</string>
+                  <integer>-451</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -774,7 +764,17 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-70</string>
+                  <integer>-70</integer>
+                  <key>y</key>
+                  <integer>590</integer>
+                </dict>
+                <dict>
+                  <key>segmentType</key>
+                  <string>line</string>
+                  <key>smooth</key>
+                  <integer>0</integer>
+                  <key>x</key>
+                  <integer>-70</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -1062,7 +1062,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>674</integer>
                 </dict>
@@ -1072,7 +1072,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>550</integer>
                 </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/kha-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/kha-deva.glif
@@ -99,7 +99,7 @@
               <key>x</key>
               <integer>268</integer>
               <key>y</key>
-              <string>-101</string>
+              <integer>-101</integer>
             </dict>
             <dict>
               <key>name</key>

--- a/Source Files/Biryani-Light.ufo/glyphs/l.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/l.glif
@@ -70,7 +70,7 @@
                   <key>x</key>
                   <integer>255</integer>
                   <key>y</key>
-                  <string>-13</string>
+                  <integer>-13</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -78,7 +78,7 @@
                   <key>x</key>
                   <integer>270</integer>
                   <key>y</key>
-                  <string>-12</string>
+                  <integer>-12</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -88,7 +88,7 @@
                   <key>x</key>
                   <integer>285</integer>
                   <key>y</key>
-                  <string>-9</string>
+                  <integer>-9</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -196,7 +196,7 @@
                   <key>x</key>
                   <integer>156</integer>
                   <key>y</key>
-                  <string>-13</string>
+                  <integer>-13</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -206,7 +206,7 @@
                   <key>x</key>
                   <integer>244</integer>
                   <key>y</key>
-                  <string>-13</string>
+                  <integer>-13</integer>
                 </dict>
               </array>
             </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/lV_ocalic-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/lV_ocalic-deva.glif
@@ -99,7 +99,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-3086</string>
+                  <integer>-3086</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -109,7 +109,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-3086</string>
+                  <integer>-3086</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -119,7 +119,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2561</string>
+                  <integer>-2561</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -129,7 +129,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2561</string>
+                  <integer>-2561</integer>
                   <key>y</key>
                   <integer>400</integer>
                 </dict>
@@ -139,7 +139,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2507</string>
+                  <integer>-2507</integer>
                   <key>y</key>
                   <integer>400</integer>
                 </dict>
@@ -149,7 +149,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2507</string>
+                  <integer>-2507</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -159,7 +159,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2297</string>
+                  <integer>-2297</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -169,7 +169,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2297</string>
+                  <integer>-2297</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -182,7 +182,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2658</string>
+                  <integer>-2658</integer>
                   <key>y</key>
                   <integer>350</integer>
                 </dict>
@@ -190,7 +190,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2717</string>
+                  <integer>-2717</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -200,7 +200,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2836</string>
+                  <integer>-2836</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -208,7 +208,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2955</string>
+                  <integer>-2955</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -216,7 +216,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-3014</string>
+                  <integer>-3014</integer>
                   <key>y</key>
                   <integer>350</integer>
                 </dict>
@@ -226,7 +226,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-3014</string>
+                  <integer>-3014</integer>
                   <key>y</key>
                   <integer>237</integer>
                 </dict>
@@ -234,7 +234,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-3014</string>
+                  <integer>-3014</integer>
                   <key>y</key>
                   <integer>122</integer>
                 </dict>
@@ -242,7 +242,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2956</string>
+                  <integer>-2956</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -252,7 +252,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-2756</string>
+                  <integer>-2756</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -262,7 +262,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2744</string>
+                  <integer>-2744</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -272,7 +272,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2744</string>
+                  <integer>-2744</integer>
                   <key>y</key>
                   <integer>44</integer>
                 </dict>
@@ -282,7 +282,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-2756</string>
+                  <integer>-2756</integer>
                   <key>y</key>
                   <integer>44</integer>
                 </dict>
@@ -290,7 +290,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2924</string>
+                  <integer>-2924</integer>
                   <key>y</key>
                   <integer>44</integer>
                 </dict>
@@ -298,7 +298,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2957</string>
+                  <integer>-2957</integer>
                   <key>y</key>
                   <integer>142</integer>
                 </dict>
@@ -308,7 +308,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2960</string>
+                  <integer>-2960</integer>
                   <key>y</key>
                   <integer>237</integer>
                 </dict>
@@ -316,7 +316,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2958</string>
+                  <integer>-2958</integer>
                   <key>y</key>
                   <integer>329</integer>
                 </dict>
@@ -324,7 +324,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2918</string>
+                  <integer>-2918</integer>
                   <key>y</key>
                   <integer>386</integer>
                 </dict>
@@ -334,7 +334,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2836</string>
+                  <integer>-2836</integer>
                   <key>y</key>
                   <integer>386</integer>
                 </dict>
@@ -342,7 +342,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2754</string>
+                  <integer>-2754</integer>
                   <key>y</key>
                   <integer>386</integer>
                 </dict>
@@ -350,7 +350,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2714</string>
+                  <integer>-2714</integer>
                   <key>y</key>
                   <integer>329</integer>
                 </dict>
@@ -360,7 +360,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2712</string>
+                  <integer>-2712</integer>
                   <key>y</key>
                   <integer>237</integer>
                 </dict>
@@ -370,7 +370,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2712</string>
+                  <integer>-2712</integer>
                   <key>y</key>
                   <integer>198</integer>
                 </dict>
@@ -380,7 +380,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2658</string>
+                  <integer>-2658</integer>
                   <key>y</key>
                   <integer>198</integer>
                 </dict>
@@ -390,7 +390,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2658</string>
+                  <integer>-2658</integer>
                   <key>y</key>
                   <integer>237</integer>
                 </dict>
@@ -405,7 +405,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2712</string>
+                  <integer>-2712</integer>
                   <key>y</key>
                   <integer>198</integer>
                 </dict>
@@ -415,7 +415,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2658</string>
+                  <integer>-2658</integer>
                   <key>y</key>
                   <integer>198</integer>
                 </dict>
@@ -425,7 +425,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2658</string>
+                  <integer>-2658</integer>
                   <key>y</key>
                   <integer>237</integer>
                 </dict>
@@ -433,7 +433,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2656</string>
+                  <integer>-2656</integer>
                   <key>y</key>
                   <integer>329</integer>
                 </dict>
@@ -441,7 +441,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2616</string>
+                  <integer>-2616</integer>
                   <key>y</key>
                   <integer>386</integer>
                 </dict>
@@ -451,7 +451,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-2534</string>
+                  <integer>-2534</integer>
                   <key>y</key>
                   <integer>386</integer>
                 </dict>
@@ -459,7 +459,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2468</string>
+                  <integer>-2468</integer>
                   <key>y</key>
                   <integer>386</integer>
                 </dict>
@@ -467,7 +467,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2430</string>
+                  <integer>-2430</integer>
                   <key>y</key>
                   <integer>356</integer>
                 </dict>
@@ -477,7 +477,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-2430</string>
+                  <integer>-2430</integer>
                   <key>y</key>
                   <integer>295</integer>
                 </dict>
@@ -485,7 +485,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2430</string>
+                  <integer>-2430</integer>
                   <key>y</key>
                   <integer>168</integer>
                 </dict>
@@ -493,7 +493,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2588</string>
+                  <integer>-2588</integer>
                   <key>y</key>
                   <integer>115</integer>
                 </dict>
@@ -503,7 +503,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-2591</string>
+                  <integer>-2591</integer>
                   <key>y</key>
                   <integer>12</integer>
                 </dict>
@@ -511,17 +511,17 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2593</string>
+                  <integer>-2593</integer>
                   <key>y</key>
-                  <string>-43</string>
+                  <integer>-43</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2544</string>
+                  <integer>-2544</integer>
                   <key>y</key>
-                  <string>-97</string>
+                  <integer>-97</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -529,25 +529,25 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-2446</string>
+                  <integer>-2446</integer>
                   <key>y</key>
-                  <string>-97</string>
+                  <integer>-97</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2395</string>
+                  <integer>-2395</integer>
                   <key>y</key>
-                  <string>-97</string>
+                  <integer>-97</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2360</string>
+                  <integer>-2360</integer>
                   <key>y</key>
-                  <string>-83</string>
+                  <integer>-83</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -555,9 +555,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2329</string>
+                  <integer>-2329</integer>
                   <key>y</key>
-                  <string>-61</string>
+                  <integer>-61</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -565,25 +565,25 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2329</string>
+                  <integer>-2329</integer>
                   <key>y</key>
-                  <string>-11</string>
+                  <integer>-11</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2357</string>
+                  <integer>-2357</integer>
                   <key>y</key>
-                  <string>-31</string>
+                  <integer>-31</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2404</string>
+                  <integer>-2404</integer>
                   <key>y</key>
-                  <string>-53</string>
+                  <integer>-53</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -591,25 +591,25 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-2446</string>
+                  <integer>-2446</integer>
                   <key>y</key>
-                  <string>-53</string>
+                  <integer>-53</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2515</string>
+                  <integer>-2515</integer>
                   <key>y</key>
-                  <string>-53</string>
+                  <integer>-53</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2538</string>
+                  <integer>-2538</integer>
                   <key>y</key>
-                  <string>-24</string>
+                  <integer>-24</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -617,7 +617,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-2537</string>
+                  <integer>-2537</integer>
                   <key>y</key>
                   <integer>12</integer>
                 </dict>
@@ -625,7 +625,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2534</string>
+                  <integer>-2534</integer>
                   <key>y</key>
                   <integer>90</integer>
                 </dict>
@@ -633,7 +633,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2376</string>
+                  <integer>-2376</integer>
                   <key>y</key>
                   <integer>157</integer>
                 </dict>
@@ -643,7 +643,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-2376</string>
+                  <integer>-2376</integer>
                   <key>y</key>
                   <integer>295</integer>
                 </dict>
@@ -651,7 +651,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2376</string>
+                  <integer>-2376</integer>
                   <key>y</key>
                   <integer>368</integer>
                 </dict>
@@ -659,7 +659,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2430</string>
+                  <integer>-2430</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -669,7 +669,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-2534</string>
+                  <integer>-2534</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -677,7 +677,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2653</string>
+                  <integer>-2653</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -685,7 +685,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2712</string>
+                  <integer>-2712</integer>
                   <key>y</key>
                   <integer>350</integer>
                 </dict>
@@ -695,7 +695,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2712</string>
+                  <integer>-2712</integer>
                   <key>y</key>
                   <integer>237</integer>
                 </dict>
@@ -710,7 +710,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2317</string>
+                  <integer>-2317</integer>
                   <key>y</key>
                   <integer>674</integer>
                 </dict>
@@ -720,7 +720,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2317</string>
+                  <integer>-2317</integer>
                   <key>y</key>
                   <integer>550</integer>
                 </dict>
@@ -730,7 +730,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1842</string>
+                  <integer>-1842</integer>
                   <key>y</key>
                   <integer>550</integer>
                 </dict>
@@ -740,7 +740,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1842</string>
+                  <integer>-1842</integer>
                   <key>y</key>
                   <integer>400</integer>
                 </dict>
@@ -750,7 +750,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1688</string>
+                  <integer>-1688</integer>
                   <key>y</key>
                   <integer>400</integer>
                 </dict>
@@ -760,7 +760,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1688</string>
+                  <integer>-1688</integer>
                   <key>y</key>
                   <integer>550</integer>
                 </dict>
@@ -770,7 +770,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1528</string>
+                  <integer>-1528</integer>
                   <key>y</key>
                   <integer>550</integer>
                 </dict>
@@ -780,7 +780,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1528</string>
+                  <integer>-1528</integer>
                   <key>y</key>
                   <integer>674</integer>
                 </dict>
@@ -795,7 +795,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1943</string>
+                  <integer>-1943</integer>
                   <key>y</key>
                   <integer>198</integer>
                 </dict>
@@ -805,7 +805,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1889</string>
+                  <integer>-1889</integer>
                   <key>y</key>
                   <integer>198</integer>
                 </dict>
@@ -815,7 +815,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1889</string>
+                  <integer>-1889</integer>
                   <key>y</key>
                   <integer>237</integer>
                 </dict>
@@ -823,7 +823,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1887</string>
+                  <integer>-1887</integer>
                   <key>y</key>
                   <integer>329</integer>
                 </dict>
@@ -831,7 +831,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1847</string>
+                  <integer>-1847</integer>
                   <key>y</key>
                   <integer>386</integer>
                 </dict>
@@ -841,7 +841,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1765</string>
+                  <integer>-1765</integer>
                   <key>y</key>
                   <integer>386</integer>
                 </dict>
@@ -849,7 +849,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1699</string>
+                  <integer>-1699</integer>
                   <key>y</key>
                   <integer>386</integer>
                 </dict>
@@ -857,7 +857,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1661</string>
+                  <integer>-1661</integer>
                   <key>y</key>
                   <integer>356</integer>
                 </dict>
@@ -867,7 +867,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1661</string>
+                  <integer>-1661</integer>
                   <key>y</key>
                   <integer>295</integer>
                 </dict>
@@ -875,7 +875,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1661</string>
+                  <integer>-1661</integer>
                   <key>y</key>
                   <integer>168</integer>
                 </dict>
@@ -883,7 +883,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1819</string>
+                  <integer>-1819</integer>
                   <key>y</key>
                   <integer>115</integer>
                 </dict>
@@ -893,7 +893,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1822</string>
+                  <integer>-1822</integer>
                   <key>y</key>
                   <integer>12</integer>
                 </dict>
@@ -901,17 +901,17 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1824</string>
+                  <integer>-1824</integer>
                   <key>y</key>
-                  <string>-43</string>
+                  <integer>-43</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1775</string>
+                  <integer>-1775</integer>
                   <key>y</key>
-                  <string>-97</string>
+                  <integer>-97</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -919,25 +919,25 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1677</string>
+                  <integer>-1677</integer>
                   <key>y</key>
-                  <string>-97</string>
+                  <integer>-97</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1626</string>
+                  <integer>-1626</integer>
                   <key>y</key>
-                  <string>-97</string>
+                  <integer>-97</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1591</string>
+                  <integer>-1591</integer>
                   <key>y</key>
-                  <string>-83</string>
+                  <integer>-83</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -945,9 +945,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1560</string>
+                  <integer>-1560</integer>
                   <key>y</key>
-                  <string>-61</string>
+                  <integer>-61</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -955,25 +955,25 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1560</string>
+                  <integer>-1560</integer>
                   <key>y</key>
-                  <string>-11</string>
+                  <integer>-11</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1588</string>
+                  <integer>-1588</integer>
                   <key>y</key>
-                  <string>-31</string>
+                  <integer>-31</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1635</string>
+                  <integer>-1635</integer>
                   <key>y</key>
-                  <string>-53</string>
+                  <integer>-53</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -981,25 +981,25 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1677</string>
+                  <integer>-1677</integer>
                   <key>y</key>
-                  <string>-53</string>
+                  <integer>-53</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1746</string>
+                  <integer>-1746</integer>
                   <key>y</key>
-                  <string>-53</string>
+                  <integer>-53</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1769</string>
+                  <integer>-1769</integer>
                   <key>y</key>
-                  <string>-24</string>
+                  <integer>-24</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -1007,7 +1007,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1768</string>
+                  <integer>-1768</integer>
                   <key>y</key>
                   <integer>12</integer>
                 </dict>
@@ -1015,7 +1015,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1765</string>
+                  <integer>-1765</integer>
                   <key>y</key>
                   <integer>90</integer>
                 </dict>
@@ -1023,7 +1023,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1607</string>
+                  <integer>-1607</integer>
                   <key>y</key>
                   <integer>157</integer>
                 </dict>
@@ -1033,7 +1033,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1607</string>
+                  <integer>-1607</integer>
                   <key>y</key>
                   <integer>295</integer>
                 </dict>
@@ -1041,7 +1041,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1607</string>
+                  <integer>-1607</integer>
                   <key>y</key>
                   <integer>368</integer>
                 </dict>
@@ -1049,7 +1049,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1661</string>
+                  <integer>-1661</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -1059,7 +1059,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1765</string>
+                  <integer>-1765</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -1067,7 +1067,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1884</string>
+                  <integer>-1884</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -1075,7 +1075,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1943</string>
+                  <integer>-1943</integer>
                   <key>y</key>
                   <integer>350</integer>
                 </dict>
@@ -1085,7 +1085,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1943</string>
+                  <integer>-1943</integer>
                   <key>y</key>
                   <integer>237</integer>
                 </dict>
@@ -1098,7 +1098,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1879</string>
+                  <integer>-1879</integer>
                   <key>y</key>
                   <integer>350</integer>
                 </dict>
@@ -1106,7 +1106,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1927</string>
+                  <integer>-1927</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -1116,7 +1116,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2054</string>
+                  <integer>-2054</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -1124,7 +1124,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2182</string>
+                  <integer>-2182</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -1132,7 +1132,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2245</string>
+                  <integer>-2245</integer>
                   <key>y</key>
                   <integer>342</integer>
                 </dict>
@@ -1142,7 +1142,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-2245</string>
+                  <integer>-2245</integer>
                   <key>y</key>
                   <integer>217</integer>
                 </dict>
@@ -1150,7 +1150,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2245</string>
+                  <integer>-2245</integer>
                   <key>y</key>
                   <integer>112</integer>
                 </dict>
@@ -1158,7 +1158,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2194</string>
+                  <integer>-2194</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -1168,7 +1168,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-2017</string>
+                  <integer>-2017</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -1178,7 +1178,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1965</string>
+                  <integer>-1965</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -1188,7 +1188,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1965</string>
+                  <integer>-1965</integer>
                   <key>y</key>
                   <integer>124</integer>
                 </dict>
@@ -1198,7 +1198,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-2017</string>
+                  <integer>-2017</integer>
                   <key>y</key>
                   <integer>124</integer>
                 </dict>
@@ -1206,7 +1206,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2078</string>
+                  <integer>-2078</integer>
                   <key>y</key>
                   <integer>124</integer>
                 </dict>
@@ -1214,7 +1214,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2091</string>
+                  <integer>-2091</integer>
                   <key>y</key>
                   <integer>171</integer>
                 </dict>
@@ -1224,7 +1224,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-2091</string>
+                  <integer>-2091</integer>
                   <key>y</key>
                   <integer>217</integer>
                 </dict>
@@ -1232,7 +1232,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2091</string>
+                  <integer>-2091</integer>
                   <key>y</key>
                   <integer>280</integer>
                 </dict>
@@ -1240,7 +1240,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2073</string>
+                  <integer>-2073</integer>
                   <key>y</key>
                   <integer>306</integer>
                 </dict>
@@ -1250,7 +1250,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2034</string>
+                  <integer>-2034</integer>
                   <key>y</key>
                   <integer>306</integer>
                 </dict>
@@ -1258,7 +1258,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2001</string>
+                  <integer>-2001</integer>
                   <key>y</key>
                   <integer>306</integer>
                 </dict>
@@ -1266,7 +1266,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1983</string>
+                  <integer>-1983</integer>
                   <key>y</key>
                   <integer>280</integer>
                 </dict>
@@ -1276,7 +1276,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1983</string>
+                  <integer>-1983</integer>
                   <key>y</key>
                   <integer>217</integer>
                 </dict>
@@ -1286,7 +1286,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1983</string>
+                  <integer>-1983</integer>
                   <key>y</key>
                   <integer>198</integer>
                 </dict>
@@ -1296,7 +1296,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1879</string>
+                  <integer>-1879</integer>
                   <key>y</key>
                   <integer>198</integer>
                 </dict>
@@ -1306,7 +1306,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1879</string>
+                  <integer>-1879</integer>
                   <key>y</key>
                   <integer>237</integer>
                 </dict>
@@ -1319,7 +1319,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1935</string>
+                  <integer>-1935</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -1327,7 +1327,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1983</string>
+                  <integer>-1983</integer>
                   <key>y</key>
                   <integer>350</integer>
                 </dict>
@@ -1337,7 +1337,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1983</string>
+                  <integer>-1983</integer>
                   <key>y</key>
                   <integer>237</integer>
                 </dict>
@@ -1347,7 +1347,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1983</string>
+                  <integer>-1983</integer>
                   <key>y</key>
                   <integer>198</integer>
                 </dict>
@@ -1357,7 +1357,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1879</string>
+                  <integer>-1879</integer>
                   <key>y</key>
                   <integer>198</integer>
                 </dict>
@@ -1367,7 +1367,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1879</string>
+                  <integer>-1879</integer>
                   <key>y</key>
                   <integer>217</integer>
                 </dict>
@@ -1375,7 +1375,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1879</string>
+                  <integer>-1879</integer>
                   <key>y</key>
                   <integer>280</integer>
                 </dict>
@@ -1383,7 +1383,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1861</string>
+                  <integer>-1861</integer>
                   <key>y</key>
                   <integer>306</integer>
                 </dict>
@@ -1393,7 +1393,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1828</string>
+                  <integer>-1828</integer>
                   <key>y</key>
                   <integer>306</integer>
                 </dict>
@@ -1401,7 +1401,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1789</string>
+                  <integer>-1789</integer>
                   <key>y</key>
                   <integer>306</integer>
                 </dict>
@@ -1409,7 +1409,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1771</string>
+                  <integer>-1771</integer>
                   <key>y</key>
                   <integer>280</integer>
                 </dict>
@@ -1419,7 +1419,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1771</string>
+                  <integer>-1771</integer>
                   <key>y</key>
                   <integer>217</integer>
                 </dict>
@@ -1427,7 +1427,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1771</string>
+                  <integer>-1771</integer>
                   <key>y</key>
                   <integer>171</integer>
                 </dict>
@@ -1435,7 +1435,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1784</string>
+                  <integer>-1784</integer>
                   <key>y</key>
                   <integer>124</integer>
                 </dict>
@@ -1445,7 +1445,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1845</string>
+                  <integer>-1845</integer>
                   <key>y</key>
                   <integer>124</integer>
                 </dict>
@@ -1455,7 +1455,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1897</string>
+                  <integer>-1897</integer>
                   <key>y</key>
                   <integer>124</integer>
                 </dict>
@@ -1465,7 +1465,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1897</string>
+                  <integer>-1897</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -1475,7 +1475,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1845</string>
+                  <integer>-1845</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -1483,7 +1483,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1668</string>
+                  <integer>-1668</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -1491,7 +1491,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1617</string>
+                  <integer>-1617</integer>
                   <key>y</key>
                   <integer>112</integer>
                 </dict>
@@ -1501,7 +1501,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1617</string>
+                  <integer>-1617</integer>
                   <key>y</key>
                   <integer>217</integer>
                 </dict>
@@ -1509,7 +1509,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1617</string>
+                  <integer>-1617</integer>
                   <key>y</key>
                   <integer>342</integer>
                 </dict>
@@ -1517,7 +1517,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1680</string>
+                  <integer>-1680</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -1527,7 +1527,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1808</string>
+                  <integer>-1808</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -1542,7 +1542,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1548</string>
+                  <integer>-1548</integer>
                   <key>y</key>
                   <integer>674</integer>
                 </dict>
@@ -1552,7 +1552,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1548</string>
+                  <integer>-1548</integer>
                   <key>y</key>
                   <integer>550</integer>
                 </dict>
@@ -1562,7 +1562,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1073</string>
+                  <integer>-1073</integer>
                   <key>y</key>
                   <integer>550</integer>
                 </dict>
@@ -1572,7 +1572,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1073</string>
+                  <integer>-1073</integer>
                   <key>y</key>
                   <integer>400</integer>
                 </dict>
@@ -1582,7 +1582,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-919</string>
+                  <integer>-919</integer>
                   <key>y</key>
                   <integer>400</integer>
                 </dict>
@@ -1592,7 +1592,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-919</string>
+                  <integer>-919</integer>
                   <key>y</key>
                   <integer>550</integer>
                 </dict>
@@ -1602,7 +1602,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-759</string>
+                  <integer>-759</integer>
                   <key>y</key>
                   <integer>550</integer>
                 </dict>
@@ -1612,7 +1612,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-759</string>
+                  <integer>-759</integer>
                   <key>y</key>
                   <integer>674</integer>
                 </dict>
@@ -1625,7 +1625,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1110</string>
+                  <integer>-1110</integer>
                   <key>y</key>
                   <integer>350</integer>
                 </dict>
@@ -1633,7 +1633,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1158</string>
+                  <integer>-1158</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -1643,7 +1643,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1285</string>
+                  <integer>-1285</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -1651,7 +1651,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1413</string>
+                  <integer>-1413</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -1659,7 +1659,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1476</string>
+                  <integer>-1476</integer>
                   <key>y</key>
                   <integer>342</integer>
                 </dict>
@@ -1669,7 +1669,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1476</string>
+                  <integer>-1476</integer>
                   <key>y</key>
                   <integer>217</integer>
                 </dict>
@@ -1677,7 +1677,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1476</string>
+                  <integer>-1476</integer>
                   <key>y</key>
                   <integer>112</integer>
                 </dict>
@@ -1685,7 +1685,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1425</string>
+                  <integer>-1425</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -1695,7 +1695,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1248</string>
+                  <integer>-1248</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -1705,7 +1705,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1196</string>
+                  <integer>-1196</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -1715,7 +1715,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1196</string>
+                  <integer>-1196</integer>
                   <key>y</key>
                   <integer>124</integer>
                 </dict>
@@ -1725,7 +1725,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1248</string>
+                  <integer>-1248</integer>
                   <key>y</key>
                   <integer>124</integer>
                 </dict>
@@ -1733,7 +1733,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1309</string>
+                  <integer>-1309</integer>
                   <key>y</key>
                   <integer>124</integer>
                 </dict>
@@ -1741,7 +1741,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1322</string>
+                  <integer>-1322</integer>
                   <key>y</key>
                   <integer>171</integer>
                 </dict>
@@ -1751,7 +1751,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1322</string>
+                  <integer>-1322</integer>
                   <key>y</key>
                   <integer>217</integer>
                 </dict>
@@ -1759,7 +1759,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1322</string>
+                  <integer>-1322</integer>
                   <key>y</key>
                   <integer>280</integer>
                 </dict>
@@ -1767,7 +1767,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1304</string>
+                  <integer>-1304</integer>
                   <key>y</key>
                   <integer>306</integer>
                 </dict>
@@ -1777,7 +1777,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1265</string>
+                  <integer>-1265</integer>
                   <key>y</key>
                   <integer>306</integer>
                 </dict>
@@ -1785,7 +1785,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1232</string>
+                  <integer>-1232</integer>
                   <key>y</key>
                   <integer>306</integer>
                 </dict>
@@ -1793,7 +1793,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1214</string>
+                  <integer>-1214</integer>
                   <key>y</key>
                   <integer>280</integer>
                 </dict>
@@ -1803,7 +1803,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1214</string>
+                  <integer>-1214</integer>
                   <key>y</key>
                   <integer>217</integer>
                 </dict>
@@ -1813,7 +1813,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1214</string>
+                  <integer>-1214</integer>
                   <key>y</key>
                   <integer>198</integer>
                 </dict>
@@ -1823,7 +1823,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1110</string>
+                  <integer>-1110</integer>
                   <key>y</key>
                   <integer>198</integer>
                 </dict>
@@ -1833,7 +1833,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1110</string>
+                  <integer>-1110</integer>
                   <key>y</key>
                   <integer>237</integer>
                 </dict>
@@ -1848,7 +1848,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1174</string>
+                  <integer>-1174</integer>
                   <key>y</key>
                   <integer>198</integer>
                 </dict>
@@ -1858,7 +1858,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1120</string>
+                  <integer>-1120</integer>
                   <key>y</key>
                   <integer>198</integer>
                 </dict>
@@ -1868,7 +1868,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1120</string>
+                  <integer>-1120</integer>
                   <key>y</key>
                   <integer>237</integer>
                 </dict>
@@ -1876,7 +1876,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1118</string>
+                  <integer>-1118</integer>
                   <key>y</key>
                   <integer>329</integer>
                 </dict>
@@ -1884,7 +1884,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1078</string>
+                  <integer>-1078</integer>
                   <key>y</key>
                   <integer>386</integer>
                 </dict>
@@ -1894,7 +1894,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-996</string>
+                  <integer>-996</integer>
                   <key>y</key>
                   <integer>386</integer>
                 </dict>
@@ -1902,7 +1902,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-930</string>
+                  <integer>-930</integer>
                   <key>y</key>
                   <integer>386</integer>
                 </dict>
@@ -1910,7 +1910,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-892</string>
+                  <integer>-892</integer>
                   <key>y</key>
                   <integer>356</integer>
                 </dict>
@@ -1920,7 +1920,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-892</string>
+                  <integer>-892</integer>
                   <key>y</key>
                   <integer>295</integer>
                 </dict>
@@ -1928,7 +1928,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-892</string>
+                  <integer>-892</integer>
                   <key>y</key>
                   <integer>168</integer>
                 </dict>
@@ -1936,7 +1936,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1050</string>
+                  <integer>-1050</integer>
                   <key>y</key>
                   <integer>115</integer>
                 </dict>
@@ -1946,7 +1946,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1053</string>
+                  <integer>-1053</integer>
                   <key>y</key>
                   <integer>12</integer>
                 </dict>
@@ -1954,17 +1954,17 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1055</string>
+                  <integer>-1055</integer>
                   <key>y</key>
-                  <string>-43</string>
+                  <integer>-43</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1006</string>
+                  <integer>-1006</integer>
                   <key>y</key>
-                  <string>-97</string>
+                  <integer>-97</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -1972,25 +1972,25 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-908</string>
+                  <integer>-908</integer>
                   <key>y</key>
-                  <string>-97</string>
+                  <integer>-97</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-857</string>
+                  <integer>-857</integer>
                   <key>y</key>
-                  <string>-97</string>
+                  <integer>-97</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-822</string>
+                  <integer>-822</integer>
                   <key>y</key>
-                  <string>-83</string>
+                  <integer>-83</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -1998,9 +1998,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-791</string>
+                  <integer>-791</integer>
                   <key>y</key>
-                  <string>-61</string>
+                  <integer>-61</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -2008,25 +2008,25 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-791</string>
+                  <integer>-791</integer>
                   <key>y</key>
-                  <string>-11</string>
+                  <integer>-11</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-819</string>
+                  <integer>-819</integer>
                   <key>y</key>
-                  <string>-31</string>
+                  <integer>-31</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-866</string>
+                  <integer>-866</integer>
                   <key>y</key>
-                  <string>-53</string>
+                  <integer>-53</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -2034,25 +2034,25 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-908</string>
+                  <integer>-908</integer>
                   <key>y</key>
-                  <string>-53</string>
+                  <integer>-53</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-977</string>
+                  <integer>-977</integer>
                   <key>y</key>
-                  <string>-53</string>
+                  <integer>-53</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1000</string>
+                  <integer>-1000</integer>
                   <key>y</key>
-                  <string>-24</string>
+                  <integer>-24</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -2060,7 +2060,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-999</string>
+                  <integer>-999</integer>
                   <key>y</key>
                   <integer>12</integer>
                 </dict>
@@ -2068,7 +2068,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-996</string>
+                  <integer>-996</integer>
                   <key>y</key>
                   <integer>90</integer>
                 </dict>
@@ -2076,7 +2076,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-838</string>
+                  <integer>-838</integer>
                   <key>y</key>
                   <integer>157</integer>
                 </dict>
@@ -2086,7 +2086,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-838</string>
+                  <integer>-838</integer>
                   <key>y</key>
                   <integer>295</integer>
                 </dict>
@@ -2094,7 +2094,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-838</string>
+                  <integer>-838</integer>
                   <key>y</key>
                   <integer>368</integer>
                 </dict>
@@ -2102,7 +2102,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-892</string>
+                  <integer>-892</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -2112,7 +2112,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-996</string>
+                  <integer>-996</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -2120,7 +2120,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1115</string>
+                  <integer>-1115</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -2128,7 +2128,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1174</string>
+                  <integer>-1174</integer>
                   <key>y</key>
                   <integer>350</integer>
                 </dict>
@@ -2138,7 +2138,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1174</string>
+                  <integer>-1174</integer>
                   <key>y</key>
                   <integer>237</integer>
                 </dict>
@@ -2151,7 +2151,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1110</string>
+                  <integer>-1110</integer>
                   <key>y</key>
                   <integer>350</integer>
                 </dict>
@@ -2159,7 +2159,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1158</string>
+                  <integer>-1158</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -2169,7 +2169,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1285</string>
+                  <integer>-1285</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -2177,7 +2177,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1413</string>
+                  <integer>-1413</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -2185,7 +2185,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1476</string>
+                  <integer>-1476</integer>
                   <key>y</key>
                   <integer>342</integer>
                 </dict>
@@ -2195,7 +2195,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1476</string>
+                  <integer>-1476</integer>
                   <key>y</key>
                   <integer>217</integer>
                 </dict>
@@ -2203,7 +2203,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1476</string>
+                  <integer>-1476</integer>
                   <key>y</key>
                   <integer>112</integer>
                 </dict>
@@ -2211,7 +2211,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1425</string>
+                  <integer>-1425</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -2221,7 +2221,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1248</string>
+                  <integer>-1248</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -2231,7 +2231,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1196</string>
+                  <integer>-1196</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -2241,7 +2241,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1196</string>
+                  <integer>-1196</integer>
                   <key>y</key>
                   <integer>124</integer>
                 </dict>
@@ -2251,7 +2251,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1248</string>
+                  <integer>-1248</integer>
                   <key>y</key>
                   <integer>124</integer>
                 </dict>
@@ -2259,7 +2259,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1309</string>
+                  <integer>-1309</integer>
                   <key>y</key>
                   <integer>124</integer>
                 </dict>
@@ -2267,7 +2267,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1322</string>
+                  <integer>-1322</integer>
                   <key>y</key>
                   <integer>171</integer>
                 </dict>
@@ -2277,7 +2277,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1322</string>
+                  <integer>-1322</integer>
                   <key>y</key>
                   <integer>217</integer>
                 </dict>
@@ -2285,7 +2285,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1322</string>
+                  <integer>-1322</integer>
                   <key>y</key>
                   <integer>280</integer>
                 </dict>
@@ -2293,7 +2293,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1304</string>
+                  <integer>-1304</integer>
                   <key>y</key>
                   <integer>306</integer>
                 </dict>
@@ -2303,7 +2303,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1265</string>
+                  <integer>-1265</integer>
                   <key>y</key>
                   <integer>306</integer>
                 </dict>
@@ -2311,7 +2311,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1232</string>
+                  <integer>-1232</integer>
                   <key>y</key>
                   <integer>306</integer>
                 </dict>
@@ -2319,7 +2319,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1214</string>
+                  <integer>-1214</integer>
                   <key>y</key>
                   <integer>280</integer>
                 </dict>
@@ -2329,7 +2329,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1214</string>
+                  <integer>-1214</integer>
                   <key>y</key>
                   <integer>217</integer>
                 </dict>
@@ -2339,7 +2339,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1214</string>
+                  <integer>-1214</integer>
                   <key>y</key>
                   <integer>198</integer>
                 </dict>
@@ -2349,7 +2349,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1110</string>
+                  <integer>-1110</integer>
                   <key>y</key>
                   <integer>198</integer>
                 </dict>
@@ -2359,7 +2359,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1110</string>
+                  <integer>-1110</integer>
                   <key>y</key>
                   <integer>237</integer>
                 </dict>
@@ -2374,7 +2374,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1164</string>
+                  <integer>-1164</integer>
                   <key>y</key>
                   <integer>198</integer>
                 </dict>
@@ -2384,7 +2384,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1060</string>
+                  <integer>-1060</integer>
                   <key>y</key>
                   <integer>198</integer>
                 </dict>
@@ -2394,7 +2394,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1060</string>
+                  <integer>-1060</integer>
                   <key>y</key>
                   <integer>217</integer>
                 </dict>
@@ -2402,7 +2402,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1060</string>
+                  <integer>-1060</integer>
                   <key>y</key>
                   <integer>285</integer>
                 </dict>
@@ -2410,7 +2410,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1039</string>
+                  <integer>-1039</integer>
                   <key>y</key>
                   <integer>316</integer>
                 </dict>
@@ -2420,7 +2420,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-996</string>
+                  <integer>-996</integer>
                   <key>y</key>
                   <integer>316</integer>
                 </dict>
@@ -2428,7 +2428,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-967</string>
+                  <integer>-967</integer>
                   <key>y</key>
                   <integer>316</integer>
                 </dict>
@@ -2436,7 +2436,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-946</string>
+                  <integer>-946</integer>
                   <key>y</key>
                   <integer>302</integer>
                 </dict>
@@ -2446,7 +2446,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-927</string>
+                  <integer>-927</integer>
                   <key>y</key>
                   <integer>280</integer>
                 </dict>
@@ -2456,7 +2456,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-927</string>
+                  <integer>-927</integer>
                   <key>y</key>
                   <integer>421</integer>
                 </dict>
@@ -2464,7 +2464,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-950</string>
+                  <integer>-950</integer>
                   <key>y</key>
                   <integer>432</integer>
                 </dict>
@@ -2472,7 +2472,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-974</string>
+                  <integer>-974</integer>
                   <key>y</key>
                   <integer>440</integer>
                 </dict>
@@ -2482,7 +2482,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1006</string>
+                  <integer>-1006</integer>
                   <key>y</key>
                   <integer>440</integer>
                 </dict>
@@ -2490,7 +2490,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1123</string>
+                  <integer>-1123</integer>
                   <key>y</key>
                   <integer>440</integer>
                 </dict>
@@ -2498,7 +2498,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1164</string>
+                  <integer>-1164</integer>
                   <key>y</key>
                   <integer>360</integer>
                 </dict>
@@ -2508,7 +2508,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1164</string>
+                  <integer>-1164</integer>
                   <key>y</key>
                   <integer>247</integer>
                 </dict>
@@ -2523,7 +2523,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-779</string>
+                  <integer>-779</integer>
                   <key>y</key>
                   <integer>674</integer>
                 </dict>
@@ -2533,7 +2533,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-779</string>
+                  <integer>-779</integer>
                   <key>y</key>
                   <integer>550</integer>
                 </dict>
@@ -2543,7 +2543,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-304</string>
+                  <integer>-304</integer>
                   <key>y</key>
                   <integer>550</integer>
                 </dict>
@@ -2553,7 +2553,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-304</string>
+                  <integer>-304</integer>
                   <key>y</key>
                   <integer>400</integer>
                 </dict>
@@ -2563,7 +2563,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-150</string>
+                  <integer>-150</integer>
                   <key>y</key>
                   <integer>400</integer>
                 </dict>
@@ -2573,7 +2573,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-150</string>
+                  <integer>-150</integer>
                   <key>y</key>
                   <integer>550</integer>
                 </dict>
@@ -2606,7 +2606,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-341</string>
+                  <integer>-341</integer>
                   <key>y</key>
                   <integer>350</integer>
                 </dict>
@@ -2614,7 +2614,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-389</string>
+                  <integer>-389</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -2624,7 +2624,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-516</string>
+                  <integer>-516</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -2632,7 +2632,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-644</string>
+                  <integer>-644</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -2640,7 +2640,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-707</string>
+                  <integer>-707</integer>
                   <key>y</key>
                   <integer>342</integer>
                 </dict>
@@ -2650,7 +2650,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-707</string>
+                  <integer>-707</integer>
                   <key>y</key>
                   <integer>217</integer>
                 </dict>
@@ -2658,7 +2658,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-707</string>
+                  <integer>-707</integer>
                   <key>y</key>
                   <integer>112</integer>
                 </dict>
@@ -2666,7 +2666,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-656</string>
+                  <integer>-656</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -2676,7 +2676,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-479</string>
+                  <integer>-479</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -2686,7 +2686,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-427</string>
+                  <integer>-427</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -2696,7 +2696,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-427</string>
+                  <integer>-427</integer>
                   <key>y</key>
                   <integer>124</integer>
                 </dict>
@@ -2706,7 +2706,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-479</string>
+                  <integer>-479</integer>
                   <key>y</key>
                   <integer>124</integer>
                 </dict>
@@ -2714,7 +2714,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-540</string>
+                  <integer>-540</integer>
                   <key>y</key>
                   <integer>124</integer>
                 </dict>
@@ -2722,7 +2722,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-553</string>
+                  <integer>-553</integer>
                   <key>y</key>
                   <integer>171</integer>
                 </dict>
@@ -2732,7 +2732,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-553</string>
+                  <integer>-553</integer>
                   <key>y</key>
                   <integer>217</integer>
                 </dict>
@@ -2740,7 +2740,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-553</string>
+                  <integer>-553</integer>
                   <key>y</key>
                   <integer>280</integer>
                 </dict>
@@ -2748,7 +2748,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-535</string>
+                  <integer>-535</integer>
                   <key>y</key>
                   <integer>306</integer>
                 </dict>
@@ -2758,7 +2758,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-496</string>
+                  <integer>-496</integer>
                   <key>y</key>
                   <integer>306</integer>
                 </dict>
@@ -2766,7 +2766,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-463</string>
+                  <integer>-463</integer>
                   <key>y</key>
                   <integer>306</integer>
                 </dict>
@@ -2774,7 +2774,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-445</string>
+                  <integer>-445</integer>
                   <key>y</key>
                   <integer>280</integer>
                 </dict>
@@ -2784,7 +2784,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-445</string>
+                  <integer>-445</integer>
                   <key>y</key>
                   <integer>217</integer>
                 </dict>
@@ -2794,7 +2794,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-445</string>
+                  <integer>-445</integer>
                   <key>y</key>
                   <integer>198</integer>
                 </dict>
@@ -2804,7 +2804,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-341</string>
+                  <integer>-341</integer>
                   <key>y</key>
                   <integer>198</integer>
                 </dict>
@@ -2814,7 +2814,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-341</string>
+                  <integer>-341</integer>
                   <key>y</key>
                   <integer>237</integer>
                 </dict>
@@ -2829,7 +2829,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-395</string>
+                  <integer>-395</integer>
                   <key>y</key>
                   <integer>198</integer>
                 </dict>
@@ -2839,7 +2839,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-291</string>
+                  <integer>-291</integer>
                   <key>y</key>
                   <integer>198</integer>
                 </dict>
@@ -2849,7 +2849,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-291</string>
+                  <integer>-291</integer>
                   <key>y</key>
                   <integer>217</integer>
                 </dict>
@@ -2857,7 +2857,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-291</string>
+                  <integer>-291</integer>
                   <key>y</key>
                   <integer>280</integer>
                 </dict>
@@ -2865,7 +2865,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-266</string>
+                  <integer>-266</integer>
                   <key>y</key>
                   <integer>306</integer>
                 </dict>
@@ -2875,7 +2875,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-227</string>
+                  <integer>-227</integer>
                   <key>y</key>
                   <integer>306</integer>
                 </dict>
@@ -2883,7 +2883,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-193</string>
+                  <integer>-193</integer>
                   <key>y</key>
                   <integer>306</integer>
                 </dict>
@@ -2891,7 +2891,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-173</string>
+                  <integer>-173</integer>
                   <key>y</key>
                   <string>-0.0001290491718</string>
                 </dict>
@@ -2901,7 +2901,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-173</string>
+                  <integer>-173</integer>
                   <key>y</key>
                   <integer>245</integer>
                 </dict>
@@ -2909,7 +2909,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-173</string>
+                  <integer>-173</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -2917,7 +2917,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-334</string>
+                  <integer>-334</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -2927,7 +2927,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-334</string>
+                  <integer>-334</integer>
                   <key>y</key>
                   <integer>12</integer>
                 </dict>
@@ -2935,9 +2935,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-334</string>
+                  <integer>-334</integer>
                   <key>y</key>
-                  <string>-63</string>
+                  <integer>-63</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -2945,7 +2945,7 @@
                   <key>x</key>
                   <string>-270.7931034482759</string>
                   <key>y</key>
-                  <string>-137</string>
+                  <integer>-137</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -2953,25 +2953,25 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-139</string>
+                  <integer>-139</integer>
                   <key>y</key>
-                  <string>-137</string>
+                  <integer>-137</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-79</string>
+                  <integer>-79</integer>
                   <key>y</key>
-                  <string>-137</string>
+                  <integer>-137</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-37</string>
+                  <integer>-37</integer>
                   <key>y</key>
-                  <string>-126</string>
+                  <integer>-126</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -2979,9 +2979,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2</string>
+                  <integer>-2</integer>
                   <key>y</key>
-                  <string>-101</string>
+                  <integer>-101</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -2989,7 +2989,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-2</string>
+                  <integer>-2</integer>
                   <key>y</key>
                   <integer>29</integer>
                 </dict>
@@ -2997,7 +2997,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-33</string>
+                  <integer>-33</integer>
                   <key>y</key>
                   <integer>7</integer>
                 </dict>
@@ -3005,9 +3005,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-90</string>
+                  <integer>-90</integer>
                   <key>y</key>
-                  <string>-13</string>
+                  <integer>-13</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -3015,9 +3015,9 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-139</string>
+                  <integer>-139</integer>
                   <key>y</key>
-                  <string>-13</string>
+                  <integer>-13</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -3025,13 +3025,13 @@
                   <key>x</key>
                   <string>-170.0879120879121</string>
                   <key>y</key>
-                  <string>-13</string>
+                  <integer>-13</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-180</string>
+                  <integer>-180</integer>
                   <key>y</key>
                   <string>-2.000000000000002</string>
                 </dict>
@@ -3041,7 +3041,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-180</string>
+                  <integer>-180</integer>
                   <key>y</key>
                   <integer>12</integer>
                 </dict>
@@ -3057,7 +3057,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-19</string>
+                  <integer>-19</integer>
                   <key>y</key>
                   <integer>157</integer>
                 </dict>
@@ -3067,7 +3067,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-19</string>
+                  <integer>-19</integer>
                   <key>y</key>
                   <integer>295</integer>
                 </dict>
@@ -3075,7 +3075,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-19</string>
+                  <integer>-19</integer>
                   <key>y</key>
                   <integer>368</integer>
                 </dict>
@@ -3093,7 +3093,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-227</string>
+                  <integer>-227</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -3101,7 +3101,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-346</string>
+                  <integer>-346</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -3109,7 +3109,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-395</string>
+                  <integer>-395</integer>
                   <key>y</key>
                   <integer>350</integer>
                 </dict>
@@ -3119,7 +3119,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-395</string>
+                  <integer>-395</integer>
                   <key>y</key>
                   <integer>237</integer>
                 </dict>
@@ -3132,7 +3132,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-347</string>
+                  <integer>-347</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -3140,7 +3140,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-395</string>
+                  <integer>-395</integer>
                   <key>y</key>
                   <integer>350</integer>
                 </dict>
@@ -3150,7 +3150,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-395</string>
+                  <integer>-395</integer>
                   <key>y</key>
                   <integer>237</integer>
                 </dict>
@@ -3160,7 +3160,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-395</string>
+                  <integer>-395</integer>
                   <key>y</key>
                   <integer>198</integer>
                 </dict>
@@ -3170,7 +3170,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-291</string>
+                  <integer>-291</integer>
                   <key>y</key>
                   <integer>198</integer>
                 </dict>
@@ -3180,7 +3180,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-291</string>
+                  <integer>-291</integer>
                   <key>y</key>
                   <integer>217</integer>
                 </dict>
@@ -3188,7 +3188,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-291</string>
+                  <integer>-291</integer>
                   <key>y</key>
                   <integer>280</integer>
                 </dict>
@@ -3196,7 +3196,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-273</string>
+                  <integer>-273</integer>
                   <key>y</key>
                   <integer>306</integer>
                 </dict>
@@ -3206,7 +3206,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-240</string>
+                  <integer>-240</integer>
                   <key>y</key>
                   <integer>306</integer>
                 </dict>
@@ -3214,7 +3214,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-201</string>
+                  <integer>-201</integer>
                   <key>y</key>
                   <integer>306</integer>
                 </dict>
@@ -3222,7 +3222,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-183</string>
+                  <integer>-183</integer>
                   <key>y</key>
                   <integer>280</integer>
                 </dict>
@@ -3232,7 +3232,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-183</string>
+                  <integer>-183</integer>
                   <key>y</key>
                   <integer>217</integer>
                 </dict>
@@ -3240,7 +3240,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-183</string>
+                  <integer>-183</integer>
                   <key>y</key>
                   <integer>171</integer>
                 </dict>
@@ -3248,7 +3248,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-196</string>
+                  <integer>-196</integer>
                   <key>y</key>
                   <integer>124</integer>
                 </dict>
@@ -3258,7 +3258,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-257</string>
+                  <integer>-257</integer>
                   <key>y</key>
                   <integer>124</integer>
                 </dict>
@@ -3268,7 +3268,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-309</string>
+                  <integer>-309</integer>
                   <key>y</key>
                   <integer>124</integer>
                 </dict>
@@ -3278,7 +3278,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-309</string>
+                  <integer>-309</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -3288,7 +3288,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-257</string>
+                  <integer>-257</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -3296,7 +3296,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-80</string>
+                  <integer>-80</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -3304,7 +3304,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-29</string>
+                  <integer>-29</integer>
                   <key>y</key>
                   <integer>112</integer>
                 </dict>
@@ -3314,7 +3314,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-29</string>
+                  <integer>-29</integer>
                   <key>y</key>
                   <integer>217</integer>
                 </dict>
@@ -3322,7 +3322,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-29</string>
+                  <integer>-29</integer>
                   <key>y</key>
                   <integer>342</integer>
                 </dict>
@@ -3330,7 +3330,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-92</string>
+                  <integer>-92</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -3340,7 +3340,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-220</string>
+                  <integer>-220</integer>
                   <key>y</key>
                   <integer>430</integer>
                 </dict>
@@ -3355,7 +3355,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>674</integer>
                 </dict>
@@ -3365,7 +3365,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>550</integer>
                 </dict>
@@ -3769,7 +3769,7 @@
                   <key>x</key>
                   <integer>435</integer>
                   <key>y</key>
-                  <string>-83</string>
+                  <integer>-83</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -3777,7 +3777,7 @@
                   <key>x</key>
                   <integer>500</integer>
                   <key>y</key>
-                  <string>-137</string>
+                  <integer>-137</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -3787,7 +3787,7 @@
                   <key>x</key>
                   <integer>624</integer>
                   <key>y</key>
-                  <string>-137</string>
+                  <integer>-137</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -3795,7 +3795,7 @@
                   <key>x</key>
                   <integer>690</integer>
                   <key>y</key>
-                  <string>-137</string>
+                  <integer>-137</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -3803,7 +3803,7 @@
                   <key>x</key>
                   <integer>732</integer>
                   <key>y</key>
-                  <string>-126</string>
+                  <integer>-126</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -3813,7 +3813,7 @@
                   <key>x</key>
                   <integer>767</integer>
                   <key>y</key>
-                  <string>-101</string>
+                  <integer>-101</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -3839,7 +3839,7 @@
                   <key>x</key>
                   <integer>683</integer>
                   <key>y</key>
-                  <string>-13</string>
+                  <integer>-13</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -3849,7 +3849,7 @@
                   <key>x</key>
                   <integer>637</integer>
                   <key>y</key>
-                  <string>-13</string>
+                  <integer>-13</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -3857,7 +3857,7 @@
                   <key>x</key>
                   <integer>608</integer>
                   <key>y</key>
-                  <string>-13</string>
+                  <integer>-13</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -3865,7 +3865,7 @@
                   <key>x</key>
                   <integer>589</integer>
                   <key>y</key>
-                  <string>-2</string>
+                  <integer>-2</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>

--- a/Source Files/Biryani-Light.ufo/glyphs/llV_ocalic-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/llV_ocalic-deva.glif
@@ -123,7 +123,7 @@
                   <key>x</key>
                   <integer>597</integer>
                   <key>y</key>
-                  <string>-223</string>
+                  <integer>-223</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -131,7 +131,7 @@
                   <key>x</key>
                   <integer>564</integer>
                   <key>y</key>
-                  <string>-207</string>
+                  <integer>-207</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -141,7 +141,7 @@
                   <key>x</key>
                   <integer>564</integer>
                   <key>y</key>
-                  <string>-160</string>
+                  <integer>-160</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -149,7 +149,7 @@
                   <key>x</key>
                   <integer>564</integer>
                   <key>y</key>
-                  <string>-127</string>
+                  <integer>-127</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -157,7 +157,7 @@
                   <key>x</key>
                   <integer>578</integer>
                   <key>y</key>
-                  <string>-104</string>
+                  <integer>-104</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -167,7 +167,7 @@
                   <key>x</key>
                   <integer>605</integer>
                   <key>y</key>
-                  <string>-89</string>
+                  <integer>-89</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -177,7 +177,7 @@
                   <key>x</key>
                   <integer>582</integer>
                   <key>y</key>
-                  <string>-92</string>
+                  <integer>-92</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -185,7 +185,7 @@
                   <key>x</key>
                   <integer>593</integer>
                   <key>y</key>
-                  <string>-95</string>
+                  <integer>-95</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -193,7 +193,7 @@
                   <key>x</key>
                   <integer>614</integer>
                   <key>y</key>
-                  <string>-97</string>
+                  <integer>-97</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -203,7 +203,7 @@
                   <key>x</key>
                   <integer>631</integer>
                   <key>y</key>
-                  <string>-97</string>
+                  <integer>-97</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -211,7 +211,7 @@
                   <key>x</key>
                   <integer>655</integer>
                   <key>y</key>
-                  <string>-97</string>
+                  <integer>-97</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -219,7 +219,7 @@
                   <key>x</key>
                   <integer>670</integer>
                   <key>y</key>
-                  <string>-94</string>
+                  <integer>-94</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -229,7 +229,7 @@
                   <key>x</key>
                   <integer>682</integer>
                   <key>y</key>
-                  <string>-91</string>
+                  <integer>-91</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -239,7 +239,7 @@
                   <key>x</key>
                   <integer>682</integer>
                   <key>y</key>
-                  <string>-44</string>
+                  <integer>-44</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -247,7 +247,7 @@
                   <key>x</key>
                   <integer>665</integer>
                   <key>y</key>
-                  <string>-49</string>
+                  <integer>-49</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -255,7 +255,7 @@
                   <key>x</key>
                   <integer>648</integer>
                   <key>y</key>
-                  <string>-53</string>
+                  <integer>-53</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -265,7 +265,7 @@
                   <key>x</key>
                   <integer>630</integer>
                   <key>y</key>
-                  <string>-53</string>
+                  <integer>-53</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -273,7 +273,7 @@
                   <key>x</key>
                   <integer>561</integer>
                   <key>y</key>
-                  <string>-53</string>
+                  <integer>-53</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -281,7 +281,7 @@
                   <key>x</key>
                   <integer>538</integer>
                   <key>y</key>
-                  <string>-24</string>
+                  <integer>-24</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -485,7 +485,7 @@
                   <key>x</key>
                   <integer>484</integer>
                   <key>y</key>
-                  <string>-29</string>
+                  <integer>-29</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -493,7 +493,7 @@
                   <key>x</key>
                   <integer>510</integer>
                   <key>y</key>
-                  <string>-69</string>
+                  <integer>-69</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -503,7 +503,7 @@
                   <key>x</key>
                   <integer>564</integer>
                   <key>y</key>
-                  <string>-87</string>
+                  <integer>-87</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -513,7 +513,7 @@
                   <key>x</key>
                   <integer>559</integer>
                   <key>y</key>
-                  <string>-69</string>
+                  <integer>-69</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -521,7 +521,7 @@
                   <key>x</key>
                   <integer>525</integer>
                   <key>y</key>
-                  <string>-87</string>
+                  <integer>-87</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -529,7 +529,7 @@
                   <key>x</key>
                   <integer>510</integer>
                   <key>y</key>
-                  <string>-119</string>
+                  <integer>-119</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -539,7 +539,7 @@
                   <key>x</key>
                   <integer>510</integer>
                   <key>y</key>
-                  <string>-160</string>
+                  <integer>-160</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -547,7 +547,7 @@
                   <key>x</key>
                   <integer>510</integer>
                   <key>y</key>
-                  <string>-235</string>
+                  <integer>-235</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -555,7 +555,7 @@
                   <key>x</key>
                   <integer>556</integer>
                   <key>y</key>
-                  <string>-267</string>
+                  <integer>-267</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -565,7 +565,7 @@
                   <key>x</key>
                   <integer>652</integer>
                   <key>y</key>
-                  <string>-267</string>
+                  <integer>-267</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -573,7 +573,7 @@
                   <key>x</key>
                   <integer>685</integer>
                   <key>y</key>
-                  <string>-267</string>
+                  <integer>-267</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -581,7 +581,7 @@
                   <key>x</key>
                   <integer>719</integer>
                   <key>y</key>
-                  <string>-261</string>
+                  <integer>-261</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -591,7 +591,7 @@
                   <key>x</key>
                   <integer>752</integer>
                   <key>y</key>
-                  <string>-243</string>
+                  <integer>-243</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -601,7 +601,7 @@
                   <key>x</key>
                   <integer>752</integer>
                   <key>y</key>
-                  <string>-192</string>
+                  <integer>-192</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -609,7 +609,7 @@
                   <key>x</key>
                   <integer>719</integer>
                   <key>y</key>
-                  <string>-215</string>
+                  <integer>-215</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -617,7 +617,7 @@
                   <key>x</key>
                   <integer>687</integer>
                   <key>y</key>
-                  <string>-223</string>
+                  <integer>-223</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -627,7 +627,7 @@
                   <key>x</key>
                   <integer>652</integer>
                   <key>y</key>
-                  <string>-223</string>
+                  <integer>-223</integer>
                 </dict>
               </array>
             </dict>
@@ -640,7 +640,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -650,7 +650,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/n.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/n.glif
@@ -103,7 +103,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-941</string>
+                  <integer>-941</integer>
                   <key>y</key>
                   <integer>558</integer>
                 </dict>
@@ -111,7 +111,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1018</string>
+                  <integer>-1018</integer>
                   <key>y</key>
                   <integer>509</integer>
                 </dict>
@@ -121,7 +121,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1068</string>
+                  <integer>-1068</integer>
                   <key>y</key>
                   <integer>451</integer>
                 </dict>
@@ -131,7 +131,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1068</string>
+                  <integer>-1068</integer>
                   <key>y</key>
                   <integer>397</integer>
                 </dict>
@@ -139,7 +139,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1017</string>
+                  <integer>-1017</integer>
                   <key>y</key>
                   <integer>456</integer>
                 </dict>
@@ -147,7 +147,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-945</string>
+                  <integer>-945</integer>
                   <key>y</key>
                   <integer>504</integer>
                 </dict>
@@ -157,7 +157,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-866</string>
+                  <integer>-866</integer>
                   <key>y</key>
                   <integer>504</integer>
                 </dict>
@@ -165,7 +165,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-764</string>
+                  <integer>-764</integer>
                   <key>y</key>
                   <integer>504</integer>
                 </dict>
@@ -173,7 +173,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-731</string>
+                  <integer>-731</integer>
                   <key>y</key>
                   <integer>458</integer>
                 </dict>
@@ -183,7 +183,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-731</string>
+                  <integer>-731</integer>
                   <key>y</key>
                   <integer>330</integer>
                 </dict>
@@ -193,7 +193,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-731</string>
+                  <integer>-731</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -203,7 +203,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-677</string>
+                  <integer>-677</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -213,7 +213,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-677</string>
+                  <integer>-677</integer>
                   <key>y</key>
                   <integer>330</integer>
                 </dict>
@@ -221,7 +221,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-677</string>
+                  <integer>-677</integer>
                   <key>y</key>
                   <integer>499</integer>
                 </dict>
@@ -229,7 +229,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-740</string>
+                  <integer>-740</integer>
                   <key>y</key>
                   <integer>558</integer>
                 </dict>
@@ -239,7 +239,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-866</string>
+                  <integer>-866</integer>
                   <key>y</key>
                   <integer>558</integer>
                 </dict>
@@ -254,7 +254,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1094</string>
+                  <integer>-1094</integer>
                   <key>y</key>
                   <integer>546</integer>
                 </dict>
@@ -264,7 +264,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1094</string>
+                  <integer>-1094</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -274,7 +274,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1040</string>
+                  <integer>-1040</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -284,7 +284,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1040</string>
+                  <integer>-1040</integer>
                   <key>y</key>
                   <integer>546</integer>
                 </dict>
@@ -315,7 +315,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-416</string>
+                  <integer>-416</integer>
                   <key>y</key>
                   <integer>451</integer>
                 </dict>
@@ -325,7 +325,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-416</string>
+                  <integer>-416</integer>
                   <key>y</key>
                   <integer>287</integer>
                 </dict>
@@ -333,7 +333,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-368</string>
+                  <integer>-368</integer>
                   <key>y</key>
                   <integer>342</integer>
                 </dict>
@@ -341,7 +341,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-313</string>
+                  <integer>-313</integer>
                   <key>y</key>
                   <integer>394</integer>
                 </dict>
@@ -351,7 +351,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-247</string>
+                  <integer>-247</integer>
                   <key>y</key>
                   <integer>394</integer>
                 </dict>
@@ -359,7 +359,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-203</string>
+                  <integer>-203</integer>
                   <key>y</key>
                   <integer>394</integer>
                 </dict>
@@ -367,7 +367,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-189</string>
+                  <integer>-189</integer>
                   <key>y</key>
                   <integer>372</integer>
                 </dict>
@@ -377,7 +377,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-189</string>
+                  <integer>-189</integer>
                   <key>y</key>
                   <integer>310</integer>
                 </dict>
@@ -387,7 +387,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-189</string>
+                  <integer>-189</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -423,7 +423,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-74</string>
+                  <integer>-74</integer>
                   <key>y</key>
                   <integer>558</integer>
                 </dict>
@@ -433,7 +433,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-200</string>
+                  <integer>-200</integer>
                   <key>y</key>
                   <integer>558</integer>
                 </dict>
@@ -448,7 +448,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-552</string>
+                  <integer>-552</integer>
                   <key>y</key>
                   <integer>546</integer>
                 </dict>
@@ -458,7 +458,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-552</string>
+                  <integer>-552</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -468,7 +468,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-358</string>
+                  <integer>-358</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -478,7 +478,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-358</string>
+                  <integer>-358</integer>
                   <key>y</key>
                   <integer>546</integer>
                 </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/ng_k_ssa-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/ng_k_ssa-deva.glif
@@ -178,7 +178,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-7</string>
+                  <integer>-7</integer>
                   <key>y</key>
                   <integer>478</integer>
                 </dict>
@@ -188,7 +188,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-7</string>
+                  <integer>-7</integer>
                   <key>y</key>
                   <integer>388</integer>
                 </dict>
@@ -196,7 +196,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-7</string>
+                  <integer>-7</integer>
                   <key>y</key>
                   <integer>309</integer>
                 </dict>
@@ -322,7 +322,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-36</string>
+                  <integer>-36</integer>
                   <key>y</key>
                   <integer>108</integer>
                 </dict>
@@ -507,7 +507,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-60</string>
+                  <integer>-60</integer>
                   <key>y</key>
                   <integer>674</integer>
                 </dict>
@@ -517,7 +517,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-60</string>
+                  <integer>-60</integer>
                   <key>y</key>
                   <integer>550</integer>
                 </dict>
@@ -594,7 +594,7 @@
                   <key>x</key>
                   <integer>139</integer>
                   <key>y</key>
-                  <string>-173</string>
+                  <integer>-173</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -604,7 +604,7 @@
                   <key>x</key>
                   <integer>139</integer>
                   <key>y</key>
-                  <string>-350</string>
+                  <integer>-350</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -614,7 +614,7 @@
                   <key>x</key>
                   <integer>242</integer>
                   <key>y</key>
-                  <string>-350</string>
+                  <integer>-350</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -624,7 +624,7 @@
                   <key>x</key>
                   <integer>242</integer>
                   <key>y</key>
-                  <string>-173</string>
+                  <integer>-173</integer>
                 </dict>
               </array>
             </dict>
@@ -639,7 +639,7 @@
                   <key>x</key>
                   <integer>84</integer>
                   <key>y</key>
-                  <string>-193</string>
+                  <integer>-193</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -647,7 +647,7 @@
                   <key>x</key>
                   <integer>84</integer>
                   <key>y</key>
-                  <string>-144</string>
+                  <integer>-144</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -655,7 +655,7 @@
                   <key>x</key>
                   <integer>258</integer>
                   <key>y</key>
-                  <string>-146</string>
+                  <integer>-146</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -665,7 +665,7 @@
                   <key>x</key>
                   <integer>258</integer>
                   <key>y</key>
-                  <string>-3</string>
+                  <integer>-3</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -705,7 +705,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-51</string>
+                  <integer>-51</integer>
                   <key>y</key>
                   <integer>82</integer>
                 </dict>
@@ -715,7 +715,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-51</string>
+                  <integer>-51</integer>
                   <key>y</key>
                   <integer>5</integer>
                 </dict>
@@ -725,9 +725,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-51</string>
+                  <integer>-51</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -737,7 +737,7 @@
                   <key>x</key>
                   <integer>91</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -807,15 +807,15 @@
                   <key>x</key>
                   <integer>126</integer>
                   <key>y</key>
-                  <string>-72</string>
+                  <integer>-72</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-58</string>
+                  <integer>-58</integer>
                   <key>y</key>
-                  <string>-57</string>
+                  <integer>-57</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -823,17 +823,17 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-58</string>
+                  <integer>-58</integer>
                   <key>y</key>
-                  <string>-202</string>
+                  <integer>-202</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-58</string>
+                  <integer>-58</integer>
                   <key>y</key>
-                  <string>-309</string>
+                  <integer>-309</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -841,7 +841,7 @@
                   <key>x</key>
                   <integer>29</integer>
                   <key>y</key>
-                  <string>-332</string>
+                  <integer>-332</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -851,7 +851,7 @@
                   <key>x</key>
                   <integer>85</integer>
                   <key>y</key>
-                  <string>-332</string>
+                  <integer>-332</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -861,7 +861,7 @@
                   <key>x</key>
                   <integer>89</integer>
                   <key>y</key>
-                  <string>-332</string>
+                  <integer>-332</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -869,7 +869,7 @@
                   <key>x</key>
                   <integer>125</integer>
                   <key>y</key>
-                  <string>-332</string>
+                  <integer>-332</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -887,7 +887,7 @@
                   <key>x</key>
                   <integer>156</integer>
                   <key>y</key>
-                  <string>-319</string>
+                  <integer>-319</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -897,7 +897,7 @@
                   <key>x</key>
                   <integer>156</integer>
                   <key>y</key>
-                  <string>-207</string>
+                  <integer>-207</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -913,7 +913,7 @@
                   <key>x</key>
                   <real>0.0</real>
                   <key>y</key>
-                  <string>-218</string>
+                  <integer>-218</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -923,7 +923,7 @@
                   <key>x</key>
                   <integer>121</integer>
                   <key>y</key>
-                  <string>-218</string>
+                  <integer>-218</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -933,7 +933,7 @@
                   <key>x</key>
                   <integer>117</integer>
                   <key>y</key>
-                  <string>-218</string>
+                  <integer>-218</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -941,7 +941,7 @@
                   <key>x</key>
                   <integer>96</integer>
                   <key>y</key>
-                  <string>-218</string>
+                  <integer>-218</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -949,7 +949,7 @@
                   <key>x</key>
                   <integer>84</integer>
                   <key>y</key>
-                  <string>-209</string>
+                  <integer>-209</integer>
                 </dict>
               </array>
             </dict>
@@ -974,7 +974,7 @@
                   <key>x</key>
                   <integer>313</integer>
                   <key>y</key>
-                  <string>-316</string>
+                  <integer>-316</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -984,7 +984,7 @@
                   <key>x</key>
                   <integer>466</integer>
                   <key>y</key>
-                  <string>-316</string>
+                  <integer>-316</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -1009,7 +1009,7 @@
                   <key>x</key>
                   <integer>263</integer>
                   <key>y</key>
-                  <string>-78</string>
+                  <integer>-78</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -1019,7 +1019,7 @@
                   <key>x</key>
                   <integer>263</integer>
                   <key>y</key>
-                  <string>-202</string>
+                  <integer>-202</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -1029,7 +1029,7 @@
                   <key>x</key>
                   <integer>445</integer>
                   <key>y</key>
-                  <string>-202</string>
+                  <integer>-202</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -1039,7 +1039,7 @@
                   <key>x</key>
                   <integer>445</integer>
                   <key>y</key>
-                  <string>-78</string>
+                  <integer>-78</integer>
                 </dict>
               </array>
             </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/nga-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/nga-deva.glif
@@ -83,7 +83,7 @@
               <key>x</key>
               <integer>123</integer>
               <key>y</key>
-              <string>-90</string>
+              <integer>-90</integer>
             </dict>
             <dict>
               <key>name</key>
@@ -116,7 +116,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -126,7 +126,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/nine.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/nine.glif
@@ -183,7 +183,7 @@
                   <key>x</key>
                   <integer>195</integer>
                   <key>y</key>
-                  <string>-15</string>
+                  <integer>-15</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>

--- a/Source Files/Biryani-Light.ufo/glyphs/nn_ra-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/nn_ra-deva.glif
@@ -84,7 +84,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -94,7 +94,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/nukta-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/nukta-deva.glif
@@ -27,7 +27,7 @@
               <key>x</key>
               <string>-220.8</string>
               <key>y</key>
-              <string>-117</string>
+              <integer>-117</integer>
             </dict>
           </array>
           <key>components</key>
@@ -46,7 +46,7 @@
                   <key>x</key>
                   <string>-277.8</string>
                   <key>y</key>
-                  <string>-117</string>
+                  <integer>-117</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -56,7 +56,7 @@
                   <key>x</key>
                   <string>-220.8</string>
                   <key>y</key>
-                  <string>-173</string>
+                  <integer>-173</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -66,7 +66,7 @@
                   <key>x</key>
                   <string>-163.8</string>
                   <key>y</key>
-                  <string>-117</string>
+                  <integer>-117</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -76,7 +76,7 @@
                   <key>x</key>
                   <string>-220.8</string>
                   <key>y</key>
-                  <string>-60</string>
+                  <integer>-60</integer>
                 </dict>
               </array>
             </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/ny_ca-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/ny_ca-deva.glif
@@ -72,7 +72,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -82,7 +82,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/o.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/o.glif
@@ -107,7 +107,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1122</string>
+                  <integer>-1122</integer>
                   <key>y</key>
                   <integer>562</integer>
                 </dict>
@@ -115,7 +115,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1208</string>
+                  <integer>-1208</integer>
                   <key>y</key>
                   <integer>433</integer>
                 </dict>
@@ -125,7 +125,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1208</string>
+                  <integer>-1208</integer>
                   <key>y</key>
                   <integer>273</integer>
                 </dict>
@@ -133,7 +133,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1208</string>
+                  <integer>-1208</integer>
                   <key>y</key>
                   <integer>112</integer>
                 </dict>
@@ -141,9 +141,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1122</string>
+                  <integer>-1122</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -151,23 +151,23 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-950</string>
+                  <integer>-950</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-778</string>
+                  <integer>-778</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-693</string>
+                  <integer>-693</integer>
                   <key>y</key>
                   <integer>112</integer>
                 </dict>
@@ -177,7 +177,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-693</string>
+                  <integer>-693</integer>
                   <key>y</key>
                   <integer>273</integer>
                 </dict>
@@ -185,7 +185,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-693</string>
+                  <integer>-693</integer>
                   <key>y</key>
                   <integer>433</integer>
                 </dict>
@@ -193,7 +193,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-778</string>
+                  <integer>-778</integer>
                   <key>y</key>
                   <integer>562</integer>
                 </dict>
@@ -203,7 +203,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-950</string>
+                  <integer>-950</integer>
                   <key>y</key>
                   <integer>562</integer>
                 </dict>
@@ -216,7 +216,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-819</string>
+                  <integer>-819</integer>
                   <key>y</key>
                   <integer>508</integer>
                 </dict>
@@ -224,7 +224,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-749</string>
+                  <integer>-749</integer>
                   <key>y</key>
                   <integer>403</integer>
                 </dict>
@@ -234,7 +234,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-749</string>
+                  <integer>-749</integer>
                   <key>y</key>
                   <integer>273</integer>
                 </dict>
@@ -242,7 +242,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-749</string>
+                  <integer>-749</integer>
                   <key>y</key>
                   <integer>143</integer>
                 </dict>
@@ -250,7 +250,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-819</string>
+                  <integer>-819</integer>
                   <key>y</key>
                   <integer>37</integer>
                 </dict>
@@ -260,7 +260,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-950</string>
+                  <integer>-950</integer>
                   <key>y</key>
                   <integer>37</integer>
                 </dict>
@@ -268,7 +268,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1082</string>
+                  <integer>-1082</integer>
                   <key>y</key>
                   <integer>37</integer>
                 </dict>
@@ -276,7 +276,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1152</string>
+                  <integer>-1152</integer>
                   <key>y</key>
                   <integer>143</integer>
                 </dict>
@@ -286,7 +286,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-1152</string>
+                  <integer>-1152</integer>
                   <key>y</key>
                   <integer>273</integer>
                 </dict>
@@ -294,7 +294,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1152</string>
+                  <integer>-1152</integer>
                   <key>y</key>
                   <integer>403</integer>
                 </dict>
@@ -302,7 +302,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-1082</string>
+                  <integer>-1082</integer>
                   <key>y</key>
                   <integer>508</integer>
                 </dict>
@@ -312,7 +312,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-950</string>
+                  <integer>-950</integer>
                   <key>y</key>
                   <integer>508</integer>
                 </dict>
@@ -333,7 +333,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-599</string>
+                  <integer>-599</integer>
                   <key>y</key>
                   <integer>433</integer>
                 </dict>
@@ -343,7 +343,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-599</string>
+                  <integer>-599</integer>
                   <key>y</key>
                   <integer>273</integer>
                 </dict>
@@ -351,7 +351,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-599</string>
+                  <integer>-599</integer>
                   <key>y</key>
                   <integer>112</integer>
                 </dict>
@@ -361,7 +361,7 @@
                   <key>x</key>
                   <string>-499.666666667</string>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -369,9 +369,9 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-301</string>
+                  <integer>-301</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -379,13 +379,13 @@
                   <key>x</key>
                   <string>-102.229571984</string>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-4</string>
+                  <integer>-4</integer>
                   <key>y</key>
                   <integer>112</integer>
                 </dict>
@@ -395,7 +395,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-4</string>
+                  <integer>-4</integer>
                   <key>y</key>
                   <integer>273</integer>
                 </dict>
@@ -403,7 +403,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-4</string>
+                  <integer>-4</integer>
                   <key>y</key>
                   <integer>433</integer>
                 </dict>
@@ -421,7 +421,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-301</string>
+                  <integer>-301</integer>
                   <key>y</key>
                   <integer>562</integer>
                 </dict>
@@ -442,7 +442,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-200</string>
+                  <integer>-200</integer>
                   <key>y</key>
                   <integer>350</integer>
                 </dict>
@@ -452,7 +452,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-200</string>
+                  <integer>-200</integer>
                   <key>y</key>
                   <integer>273</integer>
                 </dict>
@@ -460,7 +460,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-200</string>
+                  <integer>-200</integer>
                   <key>y</key>
                   <integer>196</integer>
                 </dict>
@@ -478,7 +478,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-301</string>
+                  <integer>-301</integer>
                   <key>y</key>
                   <integer>142</integer>
                 </dict>
@@ -494,7 +494,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-403</string>
+                  <integer>-403</integer>
                   <key>y</key>
                   <integer>196</integer>
                 </dict>
@@ -504,7 +504,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-403</string>
+                  <integer>-403</integer>
                   <key>y</key>
                   <integer>273</integer>
                 </dict>
@@ -512,7 +512,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-403</string>
+                  <integer>-403</integer>
                   <key>y</key>
                   <integer>350</integer>
                 </dict>
@@ -530,7 +530,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-301</string>
+                  <integer>-301</integer>
                   <key>y</key>
                   <integer>403</integer>
                 </dict>
@@ -579,7 +579,7 @@
                   <key>x</key>
                   <integer>176</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -589,7 +589,7 @@
                   <key>x</key>
                   <integer>348</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -597,7 +597,7 @@
                   <key>x</key>
                   <integer>520</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>

--- a/Source Files/Biryani-Light.ufo/glyphs/ogonek.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/ogonek.glif
@@ -43,7 +43,7 @@
           <key>x</key>
           <integer>392</integer>
           <key>y</key>
-          <string>-188</string>
+          <integer>-188</integer>
         </dict>
       </array>
       <key>com.typemytype.robofont.layerData</key>
@@ -75,7 +75,7 @@
                   <key>x</key>
                   <integer>357</integer>
                   <key>y</key>
-                  <string>-223</string>
+                  <integer>-223</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -83,7 +83,7 @@
                   <key>x</key>
                   <integer>374</integer>
                   <key>y</key>
-                  <string>-220</string>
+                  <integer>-220</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -93,7 +93,7 @@
                   <key>x</key>
                   <integer>392</integer>
                   <key>y</key>
-                  <string>-212</string>
+                  <integer>-212</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -103,7 +103,7 @@
                   <key>x</key>
                   <integer>392</integer>
                   <key>y</key>
-                  <string>-164</string>
+                  <integer>-164</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -111,7 +111,7 @@
                   <key>x</key>
                   <integer>373</integer>
                   <key>y</key>
-                  <string>-174</string>
+                  <integer>-174</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -119,7 +119,7 @@
                   <key>x</key>
                   <integer>355</integer>
                   <key>y</key>
-                  <string>-176</string>
+                  <integer>-176</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -129,7 +129,7 @@
                   <key>x</key>
                   <integer>340</integer>
                   <key>y</key>
-                  <string>-176</string>
+                  <integer>-176</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -137,7 +137,7 @@
                   <key>x</key>
                   <integer>304</integer>
                   <key>y</key>
-                  <string>-176</string>
+                  <integer>-176</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -145,7 +145,7 @@
                   <key>x</key>
                   <integer>289</integer>
                   <key>y</key>
-                  <string>-157</string>
+                  <integer>-157</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -155,7 +155,7 @@
                   <key>x</key>
                   <integer>289</integer>
                   <key>y</key>
-                  <string>-135</string>
+                  <integer>-135</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -163,7 +163,7 @@
                   <key>x</key>
                   <integer>289</integer>
                   <key>y</key>
-                  <string>-85</string>
+                  <integer>-85</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -171,7 +171,7 @@
                   <key>x</key>
                   <integer>336</integer>
                   <key>y</key>
-                  <string>-44</string>
+                  <integer>-44</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -199,7 +199,7 @@
                   <key>x</key>
                   <integer>273</integer>
                   <key>y</key>
-                  <string>-46</string>
+                  <integer>-46</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -207,7 +207,7 @@
                   <key>x</key>
                   <integer>238</integer>
                   <key>y</key>
-                  <string>-88</string>
+                  <integer>-88</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -217,7 +217,7 @@
                   <key>x</key>
                   <integer>238</integer>
                   <key>y</key>
-                  <string>-140</string>
+                  <integer>-140</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -225,7 +225,7 @@
                   <key>x</key>
                   <integer>238</integer>
                   <key>y</key>
-                  <string>-188</string>
+                  <integer>-188</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -233,7 +233,7 @@
                   <key>x</key>
                   <integer>271</integer>
                   <key>y</key>
-                  <string>-223</string>
+                  <integer>-223</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -243,7 +243,7 @@
                   <key>x</key>
                   <integer>340</integer>
                   <key>y</key>
-                  <string>-223</string>
+                  <integer>-223</integer>
                 </dict>
               </array>
             </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/oslash.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/oslash.glif
@@ -33,7 +33,7 @@
                 <integer>0</integer>
                 <integer>0</integer>
                 <integer>1</integer>
-                <string>-10</string>
+                <integer>-10</integer>
                 <integer>0</integer>
               </array>
             </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/p.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/p.glif
@@ -91,7 +91,7 @@
                   <key>x</key>
                   <integer>143</integer>
                   <key>y</key>
-                  <string>-234</string>
+                  <integer>-234</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -101,7 +101,7 @@
                   <key>x</key>
                   <integer>197</integer>
                   <key>y</key>
-                  <string>-234</string>
+                  <integer>-234</integer>
                 </dict>
               </array>
             </dict>
@@ -298,7 +298,7 @@
                   <key>x</key>
                   <integer>290</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -308,7 +308,7 @@
                   <key>x</key>
                   <integer>361</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -316,7 +316,7 @@
                   <key>x</key>
                   <integer>502</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>

--- a/Source Files/Biryani-Light.ufo/glyphs/paragraph.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/paragraph.glif
@@ -118,7 +118,7 @@
                   <key>x</key>
                   <integer>401</integer>
                   <key>y</key>
-                  <string>-100</string>
+                  <integer>-100</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -128,7 +128,7 @@
                   <key>x</key>
                   <integer>457</integer>
                   <key>y</key>
-                  <string>-100</string>
+                  <integer>-100</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -158,7 +158,7 @@
                   <key>x</key>
                   <integer>561</integer>
                   <key>y</key>
-                  <string>-100</string>
+                  <integer>-100</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -168,7 +168,7 @@
                   <key>x</key>
                   <integer>617</integer>
                   <key>y</key>
-                  <string>-100</string>
+                  <integer>-100</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>

--- a/Source Files/Biryani-Light.ufo/glyphs/parenright.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/parenright.glif
@@ -113,7 +113,7 @@
                   <key>x</key>
                   <integer>126</integer>
                   <key>y</key>
-                  <string>-45</string>
+                  <integer>-45</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -123,7 +123,7 @@
                   <key>x</key>
                   <integer>84</integer>
                   <key>y</key>
-                  <string>-102</string>
+                  <integer>-102</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -133,7 +133,7 @@
                   <key>x</key>
                   <integer>120</integer>
                   <key>y</key>
-                  <string>-129</string>
+                  <integer>-129</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -141,7 +141,7 @@
                   <key>x</key>
                   <integer>166</integer>
                   <key>y</key>
-                  <string>-74</string>
+                  <integer>-74</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>

--- a/Source Files/Biryani-Light.ufo/glyphs/partialdiff.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/partialdiff.glif
@@ -61,7 +61,7 @@
                   <key>x</key>
                   <integer>468</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -323,7 +323,7 @@
                   <key>x</key>
                   <integer>163</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -333,7 +333,7 @@
                   <key>x</key>
                   <integer>309</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
               </array>
             </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/pha-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/pha-deva.glif
@@ -391,7 +391,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-30</string>
+                  <integer>-30</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -401,7 +401,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-30</string>
+                  <integer>-30</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/product.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/product.glif
@@ -57,7 +57,7 @@
                   <key>x</key>
                   <integer>120</integer>
                   <key>y</key>
-                  <string>-237</string>
+                  <integer>-237</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -67,7 +67,7 @@
                   <key>x</key>
                   <integer>176</integer>
                   <key>y</key>
-                  <string>-237</string>
+                  <integer>-237</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -102,7 +102,7 @@
                   <key>x</key>
                   <integer>599</integer>
                   <key>y</key>
-                  <string>-237</string>
+                  <integer>-237</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -112,7 +112,7 @@
                   <key>x</key>
                   <integer>655</integer>
                   <key>y</key>
-                  <string>-237</string>
+                  <integer>-237</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>

--- a/Source Files/Biryani-Light.ufo/glyphs/q.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/q.glif
@@ -77,7 +77,7 @@
                   <key>x</key>
                   <integer>172</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -87,7 +87,7 @@
                   <key>x</key>
                   <integer>313</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -95,7 +95,7 @@
                   <key>x</key>
                   <integer>384</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -324,7 +324,7 @@
                   <key>x</key>
                   <integer>477</integer>
                   <key>y</key>
-                  <string>-234</string>
+                  <integer>-234</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -334,7 +334,7 @@
                   <key>x</key>
                   <integer>531</integer>
                   <key>y</key>
-                  <string>-234</string>
+                  <integer>-234</integer>
                 </dict>
               </array>
             </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/ra-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/ra-deva.glif
@@ -61,7 +61,7 @@
           <key>x</key>
           <integer>442</integer>
           <key>y</key>
-          <string>-4</string>
+          <integer>-4</integer>
         </dict>
       </array>
       <key>com.typemytype.robofont.layerData</key>

--- a/Source Files/Biryani-Light.ufo/glyphs/ra_uM_atra-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/ra_uM_atra-deva.glif
@@ -82,7 +82,7 @@
           <key>x</key>
           <integer>442</integer>
           <key>y</key>
-          <string>-4</string>
+          <integer>-4</integer>
         </dict>
       </array>
       <key>com.typemytype.robofont.layerData</key>

--- a/Source Files/Biryani-Light.ufo/glyphs/ra_uuM_atra-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/ra_uuM_atra-deva.glif
@@ -90,7 +90,7 @@
           <key>x</key>
           <integer>442</integer>
           <key>y</key>
-          <string>-4</string>
+          <integer>-4</integer>
         </dict>
       </array>
       <key>com.typemytype.robofont.layerData</key>

--- a/Source Files/Biryani-Light.ufo/glyphs/rrV_ocalic-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/rrV_ocalic-deva.glif
@@ -389,7 +389,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -399,7 +399,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -641,7 +641,7 @@
                   <key>x</key>
                   <integer>611</integer>
                   <key>y</key>
-                  <string>-21</string>
+                  <integer>-21</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -651,7 +651,7 @@
                   <key>x</key>
                   <integer>733</integer>
                   <key>y</key>
-                  <string>-21</string>
+                  <integer>-21</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -661,7 +661,7 @@
                   <key>x</key>
                   <integer>778</integer>
                   <key>y</key>
-                  <string>-21</string>
+                  <integer>-21</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -720,7 +720,7 @@
                   <key>x</key>
                   <integer>660</integer>
                   <key>y</key>
-                  <string>-40</string>
+                  <integer>-40</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -728,7 +728,7 @@
                   <key>x</key>
                   <integer>690</integer>
                   <key>y</key>
-                  <string>-21</string>
+                  <integer>-21</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -738,7 +738,7 @@
                   <key>x</key>
                   <integer>738</integer>
                   <key>y</key>
-                  <string>-21</string>
+                  <integer>-21</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -748,7 +748,7 @@
                   <key>x</key>
                   <integer>758</integer>
                   <key>y</key>
-                  <string>-21</string>
+                  <integer>-21</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -784,7 +784,7 @@
                   <key>x</key>
                   <integer>606</integer>
                   <key>y</key>
-                  <string>-18</string>
+                  <integer>-18</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -794,7 +794,7 @@
                   <key>x</key>
                   <integer>606</integer>
                   <key>y</key>
-                  <string>-84</string>
+                  <integer>-84</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -802,7 +802,7 @@
                   <key>x</key>
                   <integer>606</integer>
                   <key>y</key>
-                  <string>-159</string>
+                  <integer>-159</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -810,7 +810,7 @@
                   <key>x</key>
                   <integer>652</integer>
                   <key>y</key>
-                  <string>-191</string>
+                  <integer>-191</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -820,7 +820,7 @@
                   <key>x</key>
                   <integer>748</integer>
                   <key>y</key>
-                  <string>-191</string>
+                  <integer>-191</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -828,7 +828,7 @@
                   <key>x</key>
                   <integer>781</integer>
                   <key>y</key>
-                  <string>-191</string>
+                  <integer>-191</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -836,7 +836,7 @@
                   <key>x</key>
                   <integer>815</integer>
                   <key>y</key>
-                  <string>-185</string>
+                  <integer>-185</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -846,7 +846,7 @@
                   <key>x</key>
                   <integer>848</integer>
                   <key>y</key>
-                  <string>-167</string>
+                  <integer>-167</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -856,7 +856,7 @@
                   <key>x</key>
                   <integer>848</integer>
                   <key>y</key>
-                  <string>-116</string>
+                  <integer>-116</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -864,7 +864,7 @@
                   <key>x</key>
                   <integer>815</integer>
                   <key>y</key>
-                  <string>-139</string>
+                  <integer>-139</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -872,7 +872,7 @@
                   <key>x</key>
                   <integer>783</integer>
                   <key>y</key>
-                  <string>-147</string>
+                  <integer>-147</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -882,7 +882,7 @@
                   <key>x</key>
                   <integer>748</integer>
                   <key>y</key>
-                  <string>-147</string>
+                  <integer>-147</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -890,7 +890,7 @@
                   <key>x</key>
                   <integer>693</integer>
                   <key>y</key>
-                  <string>-147</string>
+                  <integer>-147</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -898,7 +898,7 @@
                   <key>x</key>
                   <integer>660</integer>
                   <key>y</key>
-                  <string>-131</string>
+                  <integer>-131</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -908,7 +908,7 @@
                   <key>x</key>
                   <integer>660</integer>
                   <key>y</key>
-                  <string>-84</string>
+                  <integer>-84</integer>
                 </dict>
               </array>
             </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/s.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/s.glif
@@ -391,7 +391,7 @@
                   <key>x</key>
                   <integer>157</integer>
                   <key>y</key>
-                  <string>-5</string>
+                  <integer>-5</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -399,7 +399,7 @@
                   <key>x</key>
                   <integer>210</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -409,7 +409,7 @@
                   <key>x</key>
                   <integer>284</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -417,7 +417,7 @@
                   <key>x</key>
                   <integer>391</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>

--- a/Source Files/Biryani-Light.ufo/glyphs/s_r-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/s_r-deva.glif
@@ -403,7 +403,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -413,7 +413,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/section.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/section.glif
@@ -590,7 +590,7 @@
                   <key>x</key>
                   <integer>396</integer>
                   <key>y</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -598,7 +598,7 @@
                   <key>x</key>
                   <integer>359</integer>
                   <key>y</key>
-                  <string>-49</string>
+                  <integer>-49</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -608,7 +608,7 @@
                   <key>x</key>
                   <integer>267</integer>
                   <key>y</key>
-                  <string>-49</string>
+                  <integer>-49</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -616,7 +616,7 @@
                   <key>x</key>
                   <integer>208</integer>
                   <key>y</key>
-                  <string>-49</string>
+                  <integer>-49</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -624,7 +624,7 @@
                   <key>x</key>
                   <integer>156</integer>
                   <key>y</key>
-                  <string>-38</string>
+                  <integer>-38</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -634,7 +634,7 @@
                   <key>x</key>
                   <integer>105</integer>
                   <key>y</key>
-                  <string>-14</string>
+                  <integer>-14</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -644,7 +644,7 @@
                   <key>x</key>
                   <integer>105</integer>
                   <key>y</key>
-                  <string>-72</string>
+                  <integer>-72</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -652,7 +652,7 @@
                   <key>x</key>
                   <integer>157</integer>
                   <key>y</key>
-                  <string>-93</string>
+                  <integer>-93</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -660,7 +660,7 @@
                   <key>x</key>
                   <integer>207</integer>
                   <key>y</key>
-                  <string>-101</string>
+                  <integer>-101</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -670,7 +670,7 @@
                   <key>x</key>
                   <integer>267</integer>
                   <key>y</key>
-                  <string>-101</string>
+                  <integer>-101</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -678,7 +678,7 @@
                   <key>x</key>
                   <integer>382</integer>
                   <key>y</key>
-                  <string>-101</string>
+                  <integer>-101</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -686,7 +686,7 @@
                   <key>x</key>
                   <integer>453</integer>
                   <key>y</key>
-                  <string>-49</string>
+                  <integer>-49</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>

--- a/Source Files/Biryani-Light.ufo/glyphs/seven.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/seven.glif
@@ -39,7 +39,7 @@
                   <key>x</key>
                   <integer>244</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -109,7 +109,7 @@
                   <key>x</key>
                   <integer>182</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
               </array>
             </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/sh-deva.loclM_A_R_.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/sh-deva.loclM_A_R_.glif
@@ -64,7 +64,7 @@
               <key>x</key>
               <integer>92</integer>
               <key>y</key>
-              <string>-30</string>
+              <integer>-30</integer>
             </dict>
             <dict>
               <key>name</key>
@@ -88,7 +88,7 @@
               <key>x</key>
               <integer>92</integer>
               <key>y</key>
-              <string>-30</string>
+              <integer>-30</integer>
             </dict>
             <dict>
               <key>name</key>
@@ -121,7 +121,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-164</string>
+                  <integer>-164</integer>
                   <key>y</key>
                   <integer>610</integer>
                 </dict>
@@ -131,7 +131,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-164</string>
+                  <integer>-164</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -141,7 +141,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-110</string>
+                  <integer>-110</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -151,7 +151,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-110</string>
+                  <integer>-110</integer>
                   <key>y</key>
                   <integer>610</integer>
                 </dict>
@@ -166,7 +166,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-742</string>
+                  <integer>-742</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -176,7 +176,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-742</string>
+                  <integer>-742</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -209,7 +209,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-329</string>
+                  <integer>-329</integer>
                   <key>y</key>
                   <integer>453</integer>
                 </dict>
@@ -217,7 +217,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-372</string>
+                  <integer>-372</integer>
                   <key>y</key>
                   <integer>517</integer>
                 </dict>
@@ -227,7 +227,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-487</string>
+                  <integer>-487</integer>
                   <key>y</key>
                   <integer>517</integer>
                 </dict>
@@ -235,7 +235,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-597</string>
+                  <integer>-597</integer>
                   <key>y</key>
                   <integer>517</integer>
                 </dict>
@@ -243,7 +243,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-644</string>
+                  <integer>-644</integer>
                   <key>y</key>
                   <integer>454</integer>
                 </dict>
@@ -253,7 +253,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-645</string>
+                  <integer>-645</integer>
                   <key>y</key>
                   <integer>337</integer>
                 </dict>
@@ -263,7 +263,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-645</string>
+                  <integer>-645</integer>
                   <key>y</key>
                   <integer>299</integer>
                 </dict>
@@ -273,7 +273,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-591</string>
+                  <integer>-591</integer>
                   <key>y</key>
                   <integer>299</integer>
                 </dict>
@@ -283,7 +283,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-591</string>
+                  <integer>-591</integer>
                   <key>y</key>
                   <integer>337</integer>
                 </dict>
@@ -291,7 +291,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-590</string>
+                  <integer>-590</integer>
                   <key>y</key>
                   <integer>439</integer>
                 </dict>
@@ -299,7 +299,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-555</string>
+                  <integer>-555</integer>
                   <key>y</key>
                   <integer>473</integer>
                 </dict>
@@ -309,7 +309,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-487</string>
+                  <integer>-487</integer>
                   <key>y</key>
                   <integer>473</integer>
                 </dict>
@@ -317,7 +317,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-408</string>
+                  <integer>-408</integer>
                   <key>y</key>
                   <integer>473</integer>
                 </dict>
@@ -325,7 +325,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-383</string>
+                  <integer>-383</integer>
                   <key>y</key>
                   <integer>440</integer>
                 </dict>
@@ -335,7 +335,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-383</string>
+                  <integer>-383</integer>
                   <key>y</key>
                   <integer>337</integer>
                 </dict>
@@ -343,7 +343,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-384</string>
+                  <integer>-384</integer>
                   <key>y</key>
                   <integer>241</integer>
                 </dict>
@@ -351,7 +351,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-455</string>
+                  <integer>-455</integer>
                   <key>y</key>
                   <integer>181</integer>
                 </dict>
@@ -361,7 +361,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-575</string>
+                  <integer>-575</integer>
                   <key>y</key>
                   <integer>181</integer>
                 </dict>
@@ -371,7 +371,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-665</string>
+                  <integer>-665</integer>
                   <key>y</key>
                   <integer>181</integer>
                 </dict>
@@ -381,7 +381,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-665</string>
+                  <integer>-665</integer>
                   <key>y</key>
                   <integer>137</integer>
                 </dict>
@@ -391,7 +391,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-575</string>
+                  <integer>-575</integer>
                   <key>y</key>
                   <integer>137</integer>
                 </dict>
@@ -399,7 +399,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-427</string>
+                  <integer>-427</integer>
                   <key>y</key>
                   <integer>137</integer>
                 </dict>
@@ -407,7 +407,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-330</string>
+                  <integer>-330</integer>
                   <key>y</key>
                   <integer>220</integer>
                 </dict>
@@ -417,7 +417,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-329</string>
+                  <integer>-329</integer>
                   <key>y</key>
                   <integer>337</integer>
                 </dict>
@@ -432,7 +432,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-643</string>
+                  <integer>-643</integer>
                   <key>y</key>
                   <integer>153</integer>
                 </dict>
@@ -442,9 +442,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-473</string>
+                  <integer>-473</integer>
                   <key>y</key>
-                  <string>-45</string>
+                  <integer>-45</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -452,9 +452,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-437</string>
+                  <integer>-437</integer>
                   <key>y</key>
-                  <string>-15</string>
+                  <integer>-15</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -462,7 +462,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-582</string>
+                  <integer>-582</integer>
                   <key>y</key>
                   <integer>153</integer>
                 </dict>
@@ -477,7 +477,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-514</string>
+                  <integer>-514</integer>
                   <key>y</key>
                   <integer>610</integer>
                 </dict>
@@ -487,7 +487,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-514</string>
+                  <integer>-514</integer>
                   <key>y</key>
                   <integer>490</integer>
                 </dict>
@@ -497,7 +497,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-460</string>
+                  <integer>-460</integer>
                   <key>y</key>
                   <integer>490</integer>
                 </dict>
@@ -507,7 +507,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-460</string>
+                  <integer>-460</integer>
                   <key>y</key>
                   <integer>610</integer>
                 </dict>
@@ -567,7 +567,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -577,7 +577,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -845,7 +845,7 @@
                   <key>x</key>
                   <integer>259</integer>
                   <key>y</key>
-                  <string>-45</string>
+                  <integer>-45</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -855,7 +855,7 @@
                   <key>x</key>
                   <integer>295</integer>
                   <key>y</key>
-                  <string>-15</string>
+                  <integer>-15</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>

--- a/Source Files/Biryani-Light.ufo/glyphs/sha-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/sha-deva.glif
@@ -77,7 +77,7 @@
               <key>x</key>
               <integer>112</integer>
               <key>y</key>
-              <string>-50</string>
+              <integer>-50</integer>
             </dict>
             <dict>
               <key>name</key>

--- a/Source Files/Biryani-Light.ufo/glyphs/sha-deva.loclM_A_R_.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/sha-deva.loclM_A_R_.glif
@@ -79,7 +79,7 @@
               <key>x</key>
               <integer>92</integer>
               <key>y</key>
-              <string>-30</string>
+              <integer>-30</integer>
             </dict>
             <dict>
               <key>name</key>
@@ -103,7 +103,7 @@
               <key>x</key>
               <integer>92</integer>
               <key>y</key>
-              <string>-30</string>
+              <integer>-30</integer>
             </dict>
             <dict>
               <key>name</key>
@@ -136,7 +136,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-164</string>
+                  <integer>-164</integer>
                   <key>y</key>
                   <integer>610</integer>
                 </dict>
@@ -146,7 +146,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-164</string>
+                  <integer>-164</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -156,7 +156,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-110</string>
+                  <integer>-110</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -166,7 +166,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-110</string>
+                  <integer>-110</integer>
                   <key>y</key>
                   <integer>610</integer>
                 </dict>
@@ -181,7 +181,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-742</string>
+                  <integer>-742</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -191,7 +191,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-742</string>
+                  <integer>-742</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -224,7 +224,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-329</string>
+                  <integer>-329</integer>
                   <key>y</key>
                   <integer>453</integer>
                 </dict>
@@ -232,7 +232,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-372</string>
+                  <integer>-372</integer>
                   <key>y</key>
                   <integer>517</integer>
                 </dict>
@@ -242,7 +242,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-487</string>
+                  <integer>-487</integer>
                   <key>y</key>
                   <integer>517</integer>
                 </dict>
@@ -250,7 +250,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-597</string>
+                  <integer>-597</integer>
                   <key>y</key>
                   <integer>517</integer>
                 </dict>
@@ -258,7 +258,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-644</string>
+                  <integer>-644</integer>
                   <key>y</key>
                   <integer>454</integer>
                 </dict>
@@ -268,7 +268,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-645</string>
+                  <integer>-645</integer>
                   <key>y</key>
                   <integer>337</integer>
                 </dict>
@@ -278,7 +278,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-645</string>
+                  <integer>-645</integer>
                   <key>y</key>
                   <integer>299</integer>
                 </dict>
@@ -288,7 +288,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-591</string>
+                  <integer>-591</integer>
                   <key>y</key>
                   <integer>299</integer>
                 </dict>
@@ -298,7 +298,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-591</string>
+                  <integer>-591</integer>
                   <key>y</key>
                   <integer>337</integer>
                 </dict>
@@ -306,7 +306,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-590</string>
+                  <integer>-590</integer>
                   <key>y</key>
                   <integer>439</integer>
                 </dict>
@@ -314,7 +314,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-555</string>
+                  <integer>-555</integer>
                   <key>y</key>
                   <integer>473</integer>
                 </dict>
@@ -324,7 +324,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-487</string>
+                  <integer>-487</integer>
                   <key>y</key>
                   <integer>473</integer>
                 </dict>
@@ -332,7 +332,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-408</string>
+                  <integer>-408</integer>
                   <key>y</key>
                   <integer>473</integer>
                 </dict>
@@ -340,7 +340,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-383</string>
+                  <integer>-383</integer>
                   <key>y</key>
                   <integer>440</integer>
                 </dict>
@@ -350,7 +350,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-383</string>
+                  <integer>-383</integer>
                   <key>y</key>
                   <integer>337</integer>
                 </dict>
@@ -358,7 +358,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-384</string>
+                  <integer>-384</integer>
                   <key>y</key>
                   <integer>241</integer>
                 </dict>
@@ -366,7 +366,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-455</string>
+                  <integer>-455</integer>
                   <key>y</key>
                   <integer>181</integer>
                 </dict>
@@ -376,7 +376,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-575</string>
+                  <integer>-575</integer>
                   <key>y</key>
                   <integer>181</integer>
                 </dict>
@@ -386,7 +386,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-665</string>
+                  <integer>-665</integer>
                   <key>y</key>
                   <integer>181</integer>
                 </dict>
@@ -396,7 +396,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-665</string>
+                  <integer>-665</integer>
                   <key>y</key>
                   <integer>137</integer>
                 </dict>
@@ -406,7 +406,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-575</string>
+                  <integer>-575</integer>
                   <key>y</key>
                   <integer>137</integer>
                 </dict>
@@ -414,7 +414,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-427</string>
+                  <integer>-427</integer>
                   <key>y</key>
                   <integer>137</integer>
                 </dict>
@@ -422,7 +422,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-330</string>
+                  <integer>-330</integer>
                   <key>y</key>
                   <integer>220</integer>
                 </dict>
@@ -432,7 +432,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-329</string>
+                  <integer>-329</integer>
                   <key>y</key>
                   <integer>337</integer>
                 </dict>
@@ -447,7 +447,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-643</string>
+                  <integer>-643</integer>
                   <key>y</key>
                   <integer>153</integer>
                 </dict>
@@ -457,9 +457,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-473</string>
+                  <integer>-473</integer>
                   <key>y</key>
-                  <string>-45</string>
+                  <integer>-45</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -467,9 +467,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-437</string>
+                  <integer>-437</integer>
                   <key>y</key>
-                  <string>-15</string>
+                  <integer>-15</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -477,7 +477,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-582</string>
+                  <integer>-582</integer>
                   <key>y</key>
                   <integer>153</integer>
                 </dict>
@@ -492,7 +492,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-514</string>
+                  <integer>-514</integer>
                   <key>y</key>
                   <integer>610</integer>
                 </dict>
@@ -502,7 +502,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-514</string>
+                  <integer>-514</integer>
                   <key>y</key>
                   <integer>490</integer>
                 </dict>
@@ -512,7 +512,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-460</string>
+                  <integer>-460</integer>
                   <key>y</key>
                   <integer>490</integer>
                 </dict>
@@ -522,7 +522,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-460</string>
+                  <integer>-460</integer>
                   <key>y</key>
                   <integer>610</integer>
                 </dict>
@@ -582,7 +582,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -592,7 +592,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -860,7 +860,7 @@
                   <key>x</key>
                   <integer>259</integer>
                   <key>y</key>
-                  <string>-45</string>
+                  <integer>-45</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -870,7 +870,7 @@
                   <key>x</key>
                   <integer>295</integer>
                   <key>y</key>
-                  <string>-15</string>
+                  <integer>-15</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>

--- a/Source Files/Biryani-Light.ufo/glyphs/six.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/six.glif
@@ -121,7 +121,7 @@
                   <key>x</key>
                   <integer>402</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -131,7 +131,7 @@
                   <key>x</key>
                   <integer>285</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -139,7 +139,7 @@
                   <key>x</key>
                   <integer>147</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>

--- a/Source Files/Biryani-Light.ufo/glyphs/summation.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/summation.glif
@@ -51,7 +51,7 @@
                   <key>x</key>
                   <integer>124</integer>
                   <key>y</key>
-                  <string>-183</string>
+                  <integer>-183</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -61,7 +61,7 @@
                   <key>x</key>
                   <integer>137</integer>
                   <key>y</key>
-                  <string>-203</string>
+                  <integer>-203</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -101,7 +101,7 @@
                   <key>x</key>
                   <integer>80</integer>
                   <key>y</key>
-                  <string>-185</string>
+                  <integer>-185</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -111,7 +111,7 @@
                   <key>x</key>
                   <integer>80</integer>
                   <key>y</key>
-                  <string>-237</string>
+                  <integer>-237</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -121,7 +121,7 @@
                   <key>x</key>
                   <integer>609</integer>
                   <key>y</key>
-                  <string>-237</string>
+                  <integer>-237</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -131,7 +131,7 @@
                   <key>x</key>
                   <integer>609</integer>
                   <key>y</key>
-                  <string>-183</string>
+                  <integer>-183</integer>
                 </dict>
               </array>
             </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/t.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/t.glif
@@ -73,7 +73,7 @@
                   <key>x</key>
                   <integer>312</integer>
                   <key>y</key>
-                  <string>-13</string>
+                  <integer>-13</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -81,7 +81,7 @@
                   <key>x</key>
                   <integer>330</integer>
                   <key>y</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -91,7 +91,7 @@
                   <key>x</key>
                   <integer>352</integer>
                   <key>y</key>
-                  <string>-5</string>
+                  <integer>-5</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -199,7 +199,7 @@
                   <key>x</key>
                   <integer>192</integer>
                   <key>y</key>
-                  <string>-13</string>
+                  <integer>-13</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -209,7 +209,7 @@
                   <key>x</key>
                   <integer>286</integer>
                   <key>y</key>
-                  <string>-13</string>
+                  <integer>-13</integer>
                 </dict>
               </array>
             </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/t_ya-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/t_ya-deva.glif
@@ -101,7 +101,7 @@
               <key>x</key>
               <integer>148</integer>
               <key>y</key>
-              <string>-103</string>
+              <integer>-103</integer>
             </dict>
             <dict>
               <key>name</key>
@@ -140,7 +140,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-802</string>
+                  <integer>-802</integer>
                   <key>y</key>
                   <integer>374</integer>
                 </dict>
@@ -148,7 +148,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-767</string>
+                  <integer>-767</integer>
                   <key>y</key>
                   <integer>406</integer>
                 </dict>
@@ -158,7 +158,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-700</string>
+                  <integer>-700</integer>
                   <key>y</key>
                   <integer>406</integer>
                 </dict>
@@ -166,7 +166,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-633</string>
+                  <integer>-633</integer>
                   <key>y</key>
                   <integer>406</integer>
                 </dict>
@@ -174,7 +174,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-620</string>
+                  <integer>-620</integer>
                   <key>y</key>
                   <integer>392</integer>
                 </dict>
@@ -184,7 +184,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-585</string>
+                  <integer>-585</integer>
                   <key>y</key>
                   <integer>322</integer>
                 </dict>
@@ -194,7 +194,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-518</string>
+                  <integer>-518</integer>
                   <key>y</key>
                   <integer>294</integer>
                 </dict>
@@ -202,7 +202,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-577</string>
+                  <integer>-577</integer>
                   <key>y</key>
                   <integer>406</integer>
                 </dict>
@@ -210,7 +210,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-582</string>
+                  <integer>-582</integer>
                   <key>y</key>
                   <integer>450</integer>
                 </dict>
@@ -220,7 +220,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-700</string>
+                  <integer>-700</integer>
                   <key>y</key>
                   <integer>450</integer>
                 </dict>
@@ -228,7 +228,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-805</string>
+                  <integer>-805</integer>
                   <key>y</key>
                   <integer>450</integer>
                 </dict>
@@ -236,7 +236,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-858</string>
+                  <integer>-858</integer>
                   <key>y</key>
                   <integer>393</integer>
                 </dict>
@@ -246,7 +246,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-858</string>
+                  <integer>-858</integer>
                   <key>y</key>
                   <integer>227</integer>
                 </dict>
@@ -254,7 +254,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-858</string>
+                  <integer>-858</integer>
                   <key>y</key>
                   <integer>60</integer>
                 </dict>
@@ -262,7 +262,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-789</string>
+                  <integer>-789</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -272,7 +272,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-680</string>
+                  <integer>-680</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -282,7 +282,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-668</string>
+                  <integer>-668</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -292,7 +292,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-668</string>
+                  <integer>-668</integer>
                   <key>y</key>
                   <integer>44</integer>
                 </dict>
@@ -302,7 +302,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-680</string>
+                  <integer>-680</integer>
                   <key>y</key>
                   <integer>44</integer>
                 </dict>
@@ -310,7 +310,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-756</string>
+                  <integer>-756</integer>
                   <key>y</key>
                   <integer>44</integer>
                 </dict>
@@ -318,7 +318,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-802</string>
+                  <integer>-802</integer>
                   <key>y</key>
                   <integer>80</integer>
                 </dict>
@@ -328,7 +328,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-804</string>
+                  <integer>-804</integer>
                   <key>y</key>
                   <integer>227</integer>
                 </dict>
@@ -343,7 +343,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-930</string>
+                  <integer>-930</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -353,7 +353,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-930</string>
+                  <integer>-930</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -363,7 +363,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-234</string>
+                  <integer>-234</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -373,7 +373,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-234</string>
+                  <integer>-234</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -383,7 +383,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-180</string>
+                  <integer>-180</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -393,17 +393,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-180</string>
-                  <key>y</key>
-                  <integer>590</integer>
-                </dict>
-                <dict>
-                  <key>segmentType</key>
-                  <string>line</string>
-                  <key>smooth</key>
-                  <integer>0</integer>
-                  <key>x</key>
-                  <string>-60</string>
+                  <integer>-180</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -413,7 +403,17 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-60</string>
+                  <integer>-60</integer>
+                  <key>y</key>
+                  <integer>590</integer>
+                </dict>
+                <dict>
+                  <key>segmentType</key>
+                  <string>line</string>
+                  <key>smooth</key>
+                  <integer>0</integer>
+                  <key>x</key>
+                  <integer>-60</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -426,7 +426,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-432</string>
+                  <integer>-432</integer>
                   <key>y</key>
                   <integer>338</integer>
                 </dict>
@@ -434,7 +434,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-396</string>
+                  <integer>-396</integer>
                   <key>y</key>
                   <integer>388</integer>
                 </dict>
@@ -444,7 +444,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-396</string>
+                  <integer>-396</integer>
                   <key>y</key>
                   <integer>464</integer>
                 </dict>
@@ -452,7 +452,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-396</string>
+                  <integer>-396</integer>
                   <key>y</key>
                   <integer>504</integer>
                 </dict>
@@ -460,7 +460,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-412</string>
+                  <integer>-412</integer>
                   <key>y</key>
                   <integer>576</integer>
                 </dict>
@@ -470,7 +470,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-454</string>
+                  <integer>-454</integer>
                   <key>y</key>
                   <integer>629</integer>
                 </dict>
@@ -480,7 +480,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-513</string>
+                  <integer>-513</integer>
                   <key>y</key>
                   <integer>629</integer>
                 </dict>
@@ -488,7 +488,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-471</string>
+                  <integer>-471</integer>
                   <key>y</key>
                   <integer>576</integer>
                 </dict>
@@ -496,7 +496,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-450</string>
+                  <integer>-450</integer>
                   <key>y</key>
                   <integer>516</integer>
                 </dict>
@@ -506,7 +506,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-450</string>
+                  <integer>-450</integer>
                   <key>y</key>
                   <integer>464</integer>
                 </dict>
@@ -514,7 +514,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-450</string>
+                  <integer>-450</integer>
                   <key>y</key>
                   <integer>400</integer>
                 </dict>
@@ -522,7 +522,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-479</string>
+                  <integer>-479</integer>
                   <key>y</key>
                   <integer>362</integer>
                 </dict>
@@ -532,7 +532,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-585</string>
+                  <integer>-585</integer>
                   <key>y</key>
                   <integer>322</integer>
                 </dict>
@@ -540,7 +540,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-534</string>
+                  <integer>-534</integer>
                   <key>y</key>
                   <integer>211</integer>
                 </dict>
@@ -548,7 +548,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-478</string>
+                  <integer>-478</integer>
                   <key>y</key>
                   <integer>177</integer>
                 </dict>
@@ -558,7 +558,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-372</string>
+                  <integer>-372</integer>
                   <key>y</key>
                   <integer>177</integer>
                 </dict>
@@ -566,7 +566,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-332</string>
+                  <integer>-332</integer>
                   <key>y</key>
                   <integer>177</integer>
                 </dict>
@@ -574,7 +574,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-260</string>
+                  <integer>-260</integer>
                   <key>y</key>
                   <integer>190</integer>
                 </dict>
@@ -584,7 +584,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-207</string>
+                  <integer>-207</integer>
                   <key>y</key>
                   <integer>231</integer>
                 </dict>
@@ -594,7 +594,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-207</string>
+                  <integer>-207</integer>
                   <key>y</key>
                   <integer>284</integer>
                 </dict>
@@ -602,7 +602,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-260</string>
+                  <integer>-260</integer>
                   <key>y</key>
                   <integer>242</integer>
                 </dict>
@@ -610,7 +610,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-320</string>
+                  <integer>-320</integer>
                   <key>y</key>
                   <integer>221</integer>
                 </dict>
@@ -620,7 +620,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-372</string>
+                  <integer>-372</integer>
                   <key>y</key>
                   <integer>221</integer>
                 </dict>
@@ -628,7 +628,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-429</string>
+                  <integer>-429</integer>
                   <key>y</key>
                   <integer>221</integer>
                 </dict>
@@ -636,7 +636,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-483</string>
+                  <integer>-483</integer>
                   <key>y</key>
                   <integer>232</integer>
                 </dict>
@@ -646,7 +646,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-518</string>
+                  <integer>-518</integer>
                   <key>y</key>
                   <integer>294</integer>
                 </dict>
@@ -1135,7 +1135,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>674</integer>
                 </dict>
@@ -1145,7 +1145,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>550</integer>
                 </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/ta-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/ta-deva.glif
@@ -57,7 +57,7 @@
               <key>x</key>
               <integer>148</integer>
               <key>y</key>
-              <string>-103</string>
+              <integer>-103</integer>
             </dict>
             <dict>
               <key>name</key>

--- a/Source Files/Biryani-Light.ufo/glyphs/thorn.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/thorn.glif
@@ -83,7 +83,7 @@
                   <key>x</key>
                   <integer>100</integer>
                   <key>y</key>
-                  <string>-234</string>
+                  <integer>-234</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -93,7 +93,7 @@
                   <key>x</key>
                   <integer>154</integer>
                   <key>y</key>
-                  <string>-234</string>
+                  <integer>-234</integer>
                 </dict>
               </array>
             </dict>
@@ -290,7 +290,7 @@
                   <key>x</key>
                   <integer>247</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -300,7 +300,7 @@
                   <key>x</key>
                   <integer>318</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -308,7 +308,7 @@
                   <key>x</key>
                   <integer>459</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>

--- a/Source Files/Biryani-Light.ufo/glyphs/three.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/three.glif
@@ -71,7 +71,7 @@
                   <key>x</key>
                   <integer>119</integer>
                   <key>y</key>
-                  <string>-4</string>
+                  <integer>-4</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -79,7 +79,7 @@
                   <key>x</key>
                   <integer>173</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -89,7 +89,7 @@
                   <key>x</key>
                   <integer>240</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -97,7 +97,7 @@
                   <key>x</key>
                   <integer>371</integer>
                   <key>y</key>
-                  <string>-17</string>
+                  <integer>-17</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>

--- a/Source Files/Biryani-Light.ufo/glyphs/tt_ya-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/tt_ya-deva.glif
@@ -92,7 +92,7 @@
               <key>x</key>
               <integer>268</integer>
               <key>y</key>
-              <string>-80</string>
+              <integer>-80</integer>
             </dict>
             <dict>
               <key>name</key>
@@ -125,7 +125,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -135,7 +135,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/tta-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/tta-deva.glif
@@ -65,7 +65,7 @@
               <key>x</key>
               <integer>268</integer>
               <key>y</key>
-              <string>-80</string>
+              <integer>-80</integer>
             </dict>
             <dict>
               <key>name</key>
@@ -339,7 +339,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -349,7 +349,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/tth_ya-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/tth_ya-deva.glif
@@ -106,7 +106,7 @@
               <key>x</key>
               <integer>288</integer>
               <key>y</key>
-              <string>-80</string>
+              <integer>-80</integer>
             </dict>
             <dict>
               <key>name</key>

--- a/Source Files/Biryani-Light.ufo/glyphs/ttha-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/ttha-deva.glif
@@ -73,7 +73,7 @@
               <key>x</key>
               <integer>288</integer>
               <key>y</key>
-              <string>-80</string>
+              <integer>-80</integer>
             </dict>
             <dict>
               <key>name</key>

--- a/Source Files/Biryani-Light.ufo/glyphs/u-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/u-deva.glif
@@ -438,7 +438,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -448,7 +448,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/u.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/u.glif
@@ -73,7 +73,7 @@
                   <key>x</key>
                   <integer>384</integer>
                   <key>y</key>
-                  <string>-12</string>
+                  <integer>-12</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -199,7 +199,7 @@
                   <key>x</key>
                   <integer>183</integer>
                   <key>y</key>
-                  <string>-12</string>
+                  <integer>-12</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -209,7 +209,7 @@
                   <key>x</key>
                   <integer>309</integer>
                   <key>y</key>
-                  <string>-12</string>
+                  <integer>-12</integer>
                 </dict>
               </array>
             </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/uu-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/uu-deva.glif
@@ -101,7 +101,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-773</string>
+                  <integer>-773</integer>
                   <key>y</key>
                   <integer>43</integer>
                 </dict>
@@ -109,7 +109,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-685</string>
+                  <integer>-685</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -119,7 +119,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-569</string>
+                  <integer>-569</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -127,7 +127,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-453</string>
+                  <integer>-453</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -135,7 +135,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-365</string>
+                  <integer>-365</integer>
                   <key>y</key>
                   <integer>43</integer>
                 </dict>
@@ -145,7 +145,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-365</string>
+                  <integer>-365</integer>
                   <key>y</key>
                   <integer>181</integer>
                 </dict>
@@ -153,7 +153,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-365</string>
+                  <integer>-365</integer>
                   <key>y</key>
                   <integer>264</integer>
                 </dict>
@@ -161,7 +161,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-400</string>
+                  <integer>-400</integer>
                   <key>y</key>
                   <integer>334</integer>
                 </dict>
@@ -171,7 +171,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-481</string>
+                  <integer>-481</integer>
                   <key>y</key>
                   <integer>350</integer>
                 </dict>
@@ -181,7 +181,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-481</string>
+                  <integer>-481</integer>
                   <key>y</key>
                   <integer>333</integer>
                 </dict>
@@ -189,7 +189,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-403</string>
+                  <integer>-403</integer>
                   <key>y</key>
                   <integer>363</integer>
                 </dict>
@@ -197,7 +197,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-365</string>
+                  <integer>-365</integer>
                   <key>y</key>
                   <integer>410</integer>
                 </dict>
@@ -207,7 +207,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-365</string>
+                  <integer>-365</integer>
                   <key>y</key>
                   <integer>485</integer>
                 </dict>
@@ -215,7 +215,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-365</string>
+                  <integer>-365</integer>
                   <key>y</key>
                   <integer>572</integer>
                 </dict>
@@ -223,7 +223,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-405</string>
+                  <integer>-405</integer>
                   <key>y</key>
                   <integer>598</integer>
                 </dict>
@@ -233,7 +233,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-453</string>
+                  <integer>-453</integer>
                   <key>y</key>
                   <integer>626</integer>
                 </dict>
@@ -243,7 +243,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-484</string>
+                  <integer>-484</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -251,7 +251,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-438</string>
+                  <integer>-438</integer>
                   <key>y</key>
                   <integer>562</integer>
                 </dict>
@@ -259,7 +259,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-419</string>
+                  <integer>-419</integer>
                   <key>y</key>
                   <integer>540</integer>
                 </dict>
@@ -269,7 +269,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-419</string>
+                  <integer>-419</integer>
                   <key>y</key>
                   <integer>485</integer>
                 </dict>
@@ -277,7 +277,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-419</string>
+                  <integer>-419</integer>
                   <key>y</key>
                   <integer>421</integer>
                 </dict>
@@ -285,7 +285,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-460</string>
+                  <integer>-460</integer>
                   <key>y</key>
                   <integer>365</integer>
                 </dict>
@@ -295,7 +295,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-559</string>
+                  <integer>-559</integer>
                   <key>y</key>
                   <integer>365</integer>
                 </dict>
@@ -305,7 +305,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-631</string>
+                  <integer>-631</integer>
                   <key>y</key>
                   <integer>365</integer>
                 </dict>
@@ -315,7 +315,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-631</string>
+                  <integer>-631</integer>
                   <key>y</key>
                   <integer>321</integer>
                 </dict>
@@ -325,7 +325,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-560</string>
+                  <integer>-560</integer>
                   <key>y</key>
                   <integer>321</integer>
                 </dict>
@@ -333,7 +333,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-460</string>
+                  <integer>-460</integer>
                   <key>y</key>
                   <integer>321</integer>
                 </dict>
@@ -341,7 +341,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-419</string>
+                  <integer>-419</integer>
                   <key>y</key>
                   <integer>273</integer>
                 </dict>
@@ -351,7 +351,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-419</string>
+                  <integer>-419</integer>
                   <key>y</key>
                   <integer>181</integer>
                 </dict>
@@ -359,7 +359,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-419</string>
+                  <integer>-419</integer>
                   <key>y</key>
                   <integer>64</integer>
                 </dict>
@@ -367,7 +367,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-488</string>
+                  <integer>-488</integer>
                   <key>y</key>
                   <integer>44</integer>
                 </dict>
@@ -377,7 +377,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-569</string>
+                  <integer>-569</integer>
                   <key>y</key>
                   <integer>44</integer>
                 </dict>
@@ -385,7 +385,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-650</string>
+                  <integer>-650</integer>
                   <key>y</key>
                   <integer>44</integer>
                 </dict>
@@ -393,7 +393,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-719</string>
+                  <integer>-719</integer>
                   <key>y</key>
                   <integer>64</integer>
                 </dict>
@@ -403,7 +403,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-719</string>
+                  <integer>-719</integer>
                   <key>y</key>
                   <integer>181</integer>
                 </dict>
@@ -413,7 +413,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-719</string>
+                  <integer>-719</integer>
                   <key>y</key>
                   <integer>231</integer>
                 </dict>
@@ -423,7 +423,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-773</string>
+                  <integer>-773</integer>
                   <key>y</key>
                   <integer>231</integer>
                 </dict>
@@ -433,7 +433,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-773</string>
+                  <integer>-773</integer>
                   <key>y</key>
                   <integer>181</integer>
                 </dict>
@@ -446,7 +446,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-82</string>
+                  <integer>-82</integer>
                   <key>y</key>
                   <integer>286</integer>
                 </dict>
@@ -454,7 +454,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-141</string>
+                  <integer>-141</integer>
                   <key>y</key>
                   <integer>321</integer>
                 </dict>
@@ -464,7 +464,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-249</string>
+                  <integer>-249</integer>
                   <key>y</key>
                   <integer>321</integer>
                 </dict>
@@ -472,7 +472,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-309</string>
+                  <integer>-309</integer>
                   <key>y</key>
                   <integer>321</integer>
                 </dict>
@@ -480,7 +480,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-350</string>
+                  <integer>-350</integer>
                   <key>y</key>
                   <integer>302</integer>
                 </dict>
@@ -490,7 +490,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-391</string>
+                  <integer>-391</integer>
                   <key>y</key>
                   <integer>272</integer>
                 </dict>
@@ -500,7 +500,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-391</string>
+                  <integer>-391</integer>
                   <key>y</key>
                   <integer>215</integer>
                 </dict>
@@ -508,7 +508,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-358</string>
+                  <integer>-358</integer>
                   <key>y</key>
                   <integer>244</integer>
                 </dict>
@@ -516,7 +516,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-323</string>
+                  <integer>-323</integer>
                   <key>y</key>
                   <integer>277</integer>
                 </dict>
@@ -526,7 +526,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-249</string>
+                  <integer>-249</integer>
                   <key>y</key>
                   <integer>277</integer>
                 </dict>
@@ -534,7 +534,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-165</string>
+                  <integer>-165</integer>
                   <key>y</key>
                   <integer>277</integer>
                 </dict>
@@ -542,7 +542,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-136</string>
+                  <integer>-136</integer>
                   <key>y</key>
                   <integer>236</integer>
                 </dict>
@@ -552,7 +552,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-136</string>
+                  <integer>-136</integer>
                   <key>y</key>
                   <integer>161</integer>
                 </dict>
@@ -560,7 +560,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-136</string>
+                  <integer>-136</integer>
                   <key>y</key>
                   <integer>67</integer>
                 </dict>
@@ -568,7 +568,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-179</string>
+                  <integer>-179</integer>
                   <key>y</key>
                   <integer>44</integer>
                 </dict>
@@ -578,7 +578,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-249</string>
+                  <integer>-249</integer>
                   <key>y</key>
                   <integer>44</integer>
                 </dict>
@@ -588,7 +588,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-261</string>
+                  <integer>-261</integer>
                   <key>y</key>
                   <integer>44</integer>
                 </dict>
@@ -596,7 +596,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-279</string>
+                  <integer>-279</integer>
                   <key>y</key>
                   <integer>44</integer>
                 </dict>
@@ -604,7 +604,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-303</string>
+                  <integer>-303</integer>
                   <key>y</key>
                   <integer>46</integer>
                 </dict>
@@ -614,7 +614,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-321</string>
+                  <integer>-321</integer>
                   <key>y</key>
                   <integer>50</integer>
                 </dict>
@@ -624,7 +624,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-321</string>
+                  <integer>-321</integer>
                   <key>y</key>
                   <integer>5</integer>
                 </dict>
@@ -632,7 +632,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-310</string>
+                  <integer>-310</integer>
                   <key>y</key>
                   <integer>3</integer>
                 </dict>
@@ -640,7 +640,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-279</string>
+                  <integer>-279</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -650,7 +650,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-261</string>
+                  <integer>-261</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -660,7 +660,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-249</string>
+                  <integer>-249</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -668,7 +668,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-141</string>
+                  <integer>-141</integer>
                   <key>y</key>
                   <integer>0</integer>
                 </dict>
@@ -676,7 +676,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-82</string>
+                  <integer>-82</integer>
                   <key>y</key>
                   <integer>42</integer>
                 </dict>
@@ -686,7 +686,7 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-82</string>
+                  <integer>-82</integer>
                   <key>y</key>
                   <integer>161</integer>
                 </dict>
@@ -701,7 +701,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-25</string>
+                  <integer>-25</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -711,7 +711,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-25</string>
+                  <integer>-25</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -721,7 +721,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-851</string>
+                  <integer>-851</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -731,7 +731,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-851</string>
+                  <integer>-851</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>
@@ -1111,7 +1111,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>674</integer>
                 </dict>
@@ -1121,7 +1121,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>550</integer>
                 </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/va-deva.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/va-deva.glif
@@ -102,7 +102,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -112,7 +112,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-10</string>
+                  <integer>-10</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/w.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/w.glif
@@ -120,7 +120,7 @@
                   <key>x</key>
                   <integer>264</integer>
                   <key>y</key>
-                  <string>-9</string>
+                  <integer>-9</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -130,7 +130,7 @@
                   <key>x</key>
                   <integer>312</integer>
                   <key>y</key>
-                  <string>-9</string>
+                  <integer>-9</integer>
                 </dict>
               </array>
             </dict>
@@ -205,7 +205,7 @@
                   <key>x</key>
                   <integer>621</integer>
                   <key>y</key>
-                  <string>-9</string>
+                  <integer>-9</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -215,7 +215,7 @@
                   <key>x</key>
                   <integer>669</integer>
                   <key>y</key>
-                  <string>-9</string>
+                  <integer>-9</integer>
                 </dict>
               </array>
             </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/y.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/y.glif
@@ -70,7 +70,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-232</string>
+                  <integer>-232</integer>
                   <key>y</key>
                   <integer>63</integer>
                 </dict>
@@ -80,7 +80,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-427</string>
+                  <integer>-427</integer>
                   <key>y</key>
                   <integer>546</integer>
                 </dict>
@@ -90,7 +90,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-485</string>
+                  <integer>-485</integer>
                   <key>y</key>
                   <integer>546</integer>
                 </dict>
@@ -100,9 +100,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-261</string>
+                  <integer>-261</integer>
                   <key>y</key>
-                  <string>-9</string>
+                  <integer>-9</integer>
                 </dict>
               </array>
             </dict>
@@ -113,17 +113,17 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-336</string>
+                  <integer>-336</integer>
                   <key>y</key>
-                  <string>-171</string>
+                  <integer>-171</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-348</string>
+                  <integer>-348</integer>
                   <key>y</key>
-                  <string>-197</string>
+                  <integer>-197</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -131,25 +131,25 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-393</string>
+                  <integer>-393</integer>
                   <key>y</key>
-                  <string>-197</string>
+                  <integer>-197</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-408</string>
+                  <integer>-408</integer>
                   <key>y</key>
-                  <string>-197</string>
+                  <integer>-197</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-424</string>
+                  <integer>-424</integer>
                   <key>y</key>
-                  <string>-196</string>
+                  <integer>-196</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -157,9 +157,9 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-439</string>
+                  <integer>-439</integer>
                   <key>y</key>
-                  <string>-193</string>
+                  <integer>-193</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -167,25 +167,25 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-439</string>
+                  <integer>-439</integer>
                   <key>y</key>
-                  <string>-247</string>
+                  <integer>-247</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-424</string>
+                  <integer>-424</integer>
                   <key>y</key>
-                  <string>-250</string>
+                  <integer>-250</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-409</string>
+                  <integer>-409</integer>
                   <key>y</key>
-                  <string>-251</string>
+                  <integer>-251</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -193,25 +193,25 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-398</string>
+                  <integer>-398</integer>
                   <key>y</key>
-                  <string>-251</string>
+                  <integer>-251</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-306</string>
+                  <integer>-306</integer>
                   <key>y</key>
-                  <string>-251</string>
+                  <integer>-251</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-296</string>
+                  <integer>-296</integer>
                   <key>y</key>
-                  <string>-217</string>
+                  <integer>-217</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -219,9 +219,9 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-245</string>
+                  <integer>-245</integer>
                   <key>y</key>
-                  <string>-89</string>
+                  <integer>-89</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -239,7 +239,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-48</string>
+                  <integer>-48</integer>
                   <key>y</key>
                   <integer>546</integer>
                 </dict>
@@ -249,9 +249,9 @@
                   <key>smooth</key>
                   <integer>1</integer>
                   <key>x</key>
-                  <string>-301</string>
+                  <integer>-301</integer>
                   <key>y</key>
-                  <string>-84</string>
+                  <integer>-84</integer>
                 </dict>
               </array>
             </dict>
@@ -296,7 +296,7 @@
                   <key>x</key>
                   <integer>274</integer>
                   <key>y</key>
-                  <string>-9</string>
+                  <integer>-9</integer>
                 </dict>
               </array>
             </dict>
@@ -309,7 +309,7 @@
                   <key>x</key>
                   <integer>200</integer>
                   <key>y</key>
-                  <string>-171</string>
+                  <integer>-171</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -317,7 +317,7 @@
                   <key>x</key>
                   <integer>187</integer>
                   <key>y</key>
-                  <string>-197</string>
+                  <integer>-197</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -327,7 +327,7 @@
                   <key>x</key>
                   <integer>142</integer>
                   <key>y</key>
-                  <string>-197</string>
+                  <integer>-197</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -335,7 +335,7 @@
                   <key>x</key>
                   <integer>127</integer>
                   <key>y</key>
-                  <string>-197</string>
+                  <integer>-197</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -343,7 +343,7 @@
                   <key>x</key>
                   <integer>111</integer>
                   <key>y</key>
-                  <string>-196</string>
+                  <integer>-196</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -353,7 +353,7 @@
                   <key>x</key>
                   <integer>96</integer>
                   <key>y</key>
-                  <string>-193</string>
+                  <integer>-193</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -363,7 +363,7 @@
                   <key>x</key>
                   <integer>96</integer>
                   <key>y</key>
-                  <string>-247</string>
+                  <integer>-247</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -371,7 +371,7 @@
                   <key>x</key>
                   <integer>111</integer>
                   <key>y</key>
-                  <string>-250</string>
+                  <integer>-250</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -379,7 +379,7 @@
                   <key>x</key>
                   <integer>126</integer>
                   <key>y</key>
-                  <string>-251</string>
+                  <integer>-251</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -389,7 +389,7 @@
                   <key>x</key>
                   <integer>137</integer>
                   <key>y</key>
-                  <string>-251</string>
+                  <integer>-251</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -397,7 +397,7 @@
                   <key>x</key>
                   <integer>229</integer>
                   <key>y</key>
-                  <string>-251</string>
+                  <integer>-251</integer>
                 </dict>
                 <dict>
                   <key>smooth</key>
@@ -405,7 +405,7 @@
                   <key>x</key>
                   <integer>240</integer>
                   <key>y</key>
-                  <string>-217</string>
+                  <integer>-217</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -415,7 +415,7 @@
                   <key>x</key>
                   <integer>290</integer>
                   <key>y</key>
-                  <string>-89</string>
+                  <integer>-89</integer>
                 </dict>
                 <dict>
                   <key>segmentType</key>
@@ -445,7 +445,7 @@
                   <key>x</key>
                   <integer>234</integer>
                   <key>y</key>
-                  <string>-84</string>
+                  <integer>-84</integer>
                 </dict>
               </array>
             </dict>

--- a/Source Files/Biryani-Light.ufo/glyphs/ya-deva.post.glif
+++ b/Source Files/Biryani-Light.ufo/glyphs/ya-deva.post.glif
@@ -88,7 +88,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-11</string>
+                  <integer>-11</integer>
                   <key>y</key>
                   <integer>634</integer>
                 </dict>
@@ -98,7 +98,7 @@
                   <key>smooth</key>
                   <integer>0</integer>
                   <key>x</key>
-                  <string>-11</string>
+                  <integer>-11</integer>
                   <key>y</key>
                   <integer>590</integer>
                 </dict>

--- a/Source Files/Biryani-Light.ufo/lib.plist
+++ b/Source Files/Biryani-Light.ufo/lib.plist
@@ -93,7 +93,7 @@
 			<key>x</key>
 			<integer>388</integer>
 			<key>y</key>
-			<string>-350</string>
+			<integer>-350</integer>
 		</dict>
 	</array>
 	<key>com.typemytype.robofont.italicSlantOffset</key>


### PR DESCRIPTION
All negative numbers were stored as `<string>-123</string>` instead of `<integer>-123</integer>`; which made Robofont choke. I fixed all those erroneous strings.
